### PR TITLE
feat: Data and local storage setup

### DIFF
--- a/docs/adr/04-asset-domain-contracts.md
+++ b/docs/adr/04-asset-domain-contracts.md
@@ -29,15 +29,17 @@ Repository implementations must also preserve the uploaded-state invariant durin
 
 `StorageAdapterInterface` must return a fully typed `UploadTarget` for an accepted `Asset`.
 
-| Upload target field | Required behavior                                                                      | Notes                                                                    |
-| ------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `url`               | Must be an absolute URL. HTTPS is required except for local-development loopback URLs. | Validated by `UploadTarget`.                                             |
-| `method`            | Must be a supported domain upload method.                                              | The current domain contract supports `PUT`.                              |
-| `signedHeaders`     | Must be a list of `UploadParameter` objects.                                           | The contract avoids provider-specific associative arrays.                |
-| `completionProof`   | Must describe which proof the client captures and where it comes from.                 | Expressed as `UploadCompletionProof` plus `UploadCompletionProofSource`. |
-| `expiresAt`         | Must state when the target stops being valid.                                          | Consumers should treat it as a hard expiry.                              |
+| Upload target field | Required behavior                                                                                                                                    | Notes                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `url`               | Must be an absolute URL. HTTPS is required except for local-development loopback URLs and deterministic `mock://uploads/{uploadId}/chunk/0` targets. | Validated by `UploadTarget`.                                             |
+| `method`            | Must be a supported domain upload method.                                                                                                            | The current domain contract supports `PUT`.                              |
+| `signedHeaders`     | Must be a list of `UploadParameter` objects.                                                                                                         | The contract avoids provider-specific associative arrays.                |
+| `completionProof`   | Must describe which proof the client captures and where it comes from.                                                                               | Expressed as `UploadCompletionProof` plus `UploadCompletionProofSource`. |
+| `expiresAt`         | Must state when the target stops being valid.                                                                                                        | Consumers should treat it as a hard expiry.                              |
 
 Storage adapters own signing, credentials, bucket selection, and provider-specific response details. Those details stay in infrastructure and are translated into the typed domain contract before being returned.
+
+The current storage adapter interface remains singular. Until the contract grows multi-part semantics, local-development adapters return deterministic chunk `0` targets.
 
 ## Added to complete US-02
 

--- a/docs/adr/04-asset-domain-contracts.md
+++ b/docs/adr/04-asset-domain-contracts.md
@@ -2,23 +2,28 @@
 
 ## Purpose
 
-This document records the domain contract between the `Asset` aggregate, persistence, and storage for US-02. It is an implementation-level contract (not a Draw.io diagram) and belongs with the ADRs as permanent architecture documentation.
+This document records the domain contract between the `Asset` aggregate, persistence, and storage for US-02. It is an implementation-level contract and belongs with the ADRs as permanent architecture documentation.
 
 ## Asset Repository Contract
 
 `AssetRepositoryInterface` must provide these behaviors.
 
-| Method                                       | Required behavior                                                                                                                                                                                               | Why US-02 needs it                                                                                                   |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `save(Asset $asset): void`                   | Persist enough state to reconstruct the same domain object later. This includes `id`, `uploadId`, `accountId`, `fileName`, `mimeType`, `status`, `createdAt`, and `completionProof` when the asset is uploaded. | The `Asset` aggregate is the source of truth for lifecycle state. Persistence cannot drop uploaded-state proof data. |
-| `findById(AssetId $assetId): ?Asset`         | Return the matching asset or `null` when none exists.                                                                                                                                                           | Later read and completion flows need a stable lookup by asset identity.                                              |
-| `findByUploadId(UploadId $uploadId): ?Asset` | Return the matching asset or `null` when none exists.                                                                                                                                                           | The upload identifier is part of the upload flow contract and supports retry-safe lookup.                            |
+| Method                                                         | Required behavior                                                                                                                                                                                                                                              | Why US-02 needs it                                                                                                   |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `save(Asset $asset): void`                                     | Persist enough state to reconstruct the same domain object later. This includes `id`, `uploadId`, `accountId`, `fileName`, `mimeType`, `status`, `chunkCount`, `createdAt`, `updatedAt`, and `completionProof` when the asset is uploaded.                     | The `Asset` aggregate is the source of truth for lifecycle state. Persistence cannot drop uploaded-state proof data. |
+| `findById(AssetId $assetId): ?Asset`                           | Return the matching asset or `null` when none exists.                                                                                                                                                                                                          | Later read and completion flows need a stable lookup by asset identity.                                              |
+| `findByUploadId(UploadId $uploadId): ?Asset`                   | Return the matching asset or `null` when none exists.                                                                                                                                                                                                          | The upload identifier is part of the upload flow contract and supports retry-safe lookup.                            |
+| `searchByFileName(AccountId $accountId, string $query): array` | Return only assets for the supplied account whose `fileName` contains the trimmed query as a plain-text, case-insensitive substring. Results are ordered by `createdAt` descending, then `id` ascending. Return an empty list when the trimmed query is empty. | Search flows need deterministic account-scoped matching without turning an empty query into a full scan.             |
+
+Persistence must store `accountId`, `fileName`, `mimeType`, and uploaded-state `completionProof` values without truncating them to an undocumented 255-character ceiling. In this chunk the domain still models those fields as trimmed non-empty text, so persistence must preserve the full value it receives.
+
+Persistence must store `chunkCount` as a positive integer and `updatedAt` as a timestamp that is never earlier than `createdAt`. Newly created pending assets start with `chunkCount = 1` and `updatedAt === createdAt`; successful status transitions advance `updatedAt` monotonically and never move it backward.
 
 Repository implementations must also preserve the uploaded-state invariant during reads.
 
-- `PENDING` and `FAILED` assets can be reconstituted with `Asset::reconstitute(...)`.
-- `UPLOADED` assets must be reconstituted with `Asset::reconstituteUploaded(...)` and must include a completion proof value.
-- An uploaded record without completion proof is invalid domain state and must not be returned as a valid `Asset`.
+- `PENDING` and `FAILED` assets are reconstituted with `Asset::reconstitute(...)`, including persisted `chunkCount`, `createdAt`, and `updatedAt`.
+- `UPLOADED` assets are reconstituted with `Asset::reconstituteUploaded(...)`, including the same persisted lifecycle fields plus a completion proof value.
+- An uploaded record without a non-empty completion proof, a record with `chunkCount < 1`, or a record with `updatedAt < createdAt` is invalid domain state and must not be returned as a valid `Asset`.
 
 ## Storage Adapter Contract
 
@@ -39,6 +44,7 @@ Storage adapters own signing, credentials, bucket selection, and provider-specif
 The accepted delivery extended slightly beyond the original story so the domain contract would be complete.
 
 - `findByUploadId(...)` was added to the repository contract so upload flows can resolve an asset by upload identifier.
+- `searchByFileName(...)` was added to the repository contract so account-scoped file-name search has deterministic semantics before the repository implementation lands.
 - `StorageAdapterInterface` and the typed upload-target model were added so upload instructions are represented as domain types instead of untyped infrastructure payloads.
 - A completion-proof requirement was added to both upload completion and uploaded-state reconstitution so `UPLOADED` cannot exist without proof.
 

--- a/docs/api/01-agree-api-schema.md
+++ b/docs/api/01-agree-api-schema.md
@@ -173,13 +173,15 @@ Non-negative file size in bytes. This allows values beyond the GraphQL `Int` ran
 
 ### `UploadTarget`
 
-| Field             | Type                               | Description                                           |
-| ----------------- | ---------------------------------- | ----------------------------------------------------- |
-| `url`             | `String!`                          | Time-limited upload URL.                              |
-| `method`          | `UploadHttpMethod!`                | HTTP method the client must use.                      |
-| `signedHeaders`   | `[UploadParameter!]!`              | Headers that must be sent exactly as issued.          |
-| `completionProof` | `UploadCompletionProofDescriptor!` | Tells the client which proof to capture after upload. |
-| `expiresAt`       | `DateTime!`                        | Expiration timestamp for the upload target.           |
+| Field             | Type                               | Description                                                                                                                    |
+| ----------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `url`             | `String!`                          | Time-limited upload target. Production returns HTTPS; local mock may return deterministic `mock://uploads/{uploadId}/chunk/0`. |
+| `method`          | `UploadHttpMethod!`                | HTTP method the client must use.                                                                                               |
+| `signedHeaders`   | `[UploadParameter!]!`              | Headers that must be sent exactly as issued.                                                                                   |
+| `completionProof` | `UploadCompletionProofDescriptor!` | Tells the client which proof to capture after upload.                                                                          |
+| `expiresAt`       | `DateTime!`                        | Expiration timestamp for the upload target.                                                                                    |
+
+Clients must perform a network upload only when `UploadTarget.url` uses `https://`. In local development, `mock://uploads/{uploadId}/chunk/0` is a deterministic stub for test and dev flows, so clients must skip the network upload and continue with the agreed mock behavior. Clients must reject `http://` targets and any other non-HTTPS, non-`mock://` scheme as a misconfiguration and security risk.
 
 ### `UploadHttpMethod`
 

--- a/docs/logs/03-data-local-storage-setup.md
+++ b/docs/logs/03-data-local-storage-setup.md
@@ -1,0 +1,62 @@
+# Implementation Log: US-03 Data & Local Storage Setup
+
+**Feature:** US-03 Data & Local Storage Setup
+
+## Summary
+
+US-03 delivered the first durable local data path for assets and a local-development storage adapter that does not require cloud infrastructure. The accepted work covered the asset lifecycle persistence model, the assets-table bootstrap migration, a MySQL repository with stale-write protection, and a deterministic mock upload target for local development. API and ADR documentation were updated so the local mock behavior and repository and storage contract stay explicit.
+
+## Implementation Details
+
+- Extended the Asset aggregate with persisted lifecycle fields chunkCount and updatedAt. New pending assets start with chunkCount 1 and updatedAt equal to createdAt, and status transitions only advance updatedAt when time moves forward.
+- Extended AssetRepositoryInterface with account-scoped file-name search using the trimmed query as a plain-text, case-insensitive substring match with deterministic ordering.
+- Added an idempotent assets-table bootstrap migration that persists lifecycle fields and enforces uploadId uniqueness, allowed status values, positive chunk_count, completion-proof consistency, and updated_at not earlier than created_at.
+- Added MySQLAssetRepository using prepared statements with named parameters for insert, lookup, and search. The repository supports uploadId lookup, deterministic account-scoped search, no-op identical save, domain reconstitution of persisted lifecycle state, and stale-write protection.
+- Added StaleAssetWriteException in the domain so stale persistence conflicts are surfaced as a domain-owned failure.
+- Tightened UploadTarget so local mock URLs are accepted only in the exact shape mock://uploads/{uploadId}/chunk/0 while preserving existing HTTPS and loopback local-development allowances.
+- Added MockStorageAdapter to return deterministic local upload targets and typed completion-proof metadata without requiring cloud storage in local development.
+- Updated API and ADR documentation to describe deterministic local mock behavior and the lifecycle persistence and search contract.
+
+## Added to complete US-03
+
+- The lifecycle persistence fields and DB constraints were added so the first MySQL-backed asset state could be reconstructed without weakening domain invariants.
+- Account-scoped file-name search was added to the repository contract and MySQL implementation so higher layers have deterministic search semantics before runtime wiring lands.
+- Stale-write handling was added at the domain and repository boundary so repeated or competing saves fail safely instead of silently overwriting newer state.
+- The local mock upload target was narrowed to a single deterministic shape so local development stays storage-free without allowing arbitrary mock URLs.
+
+## Files Changed
+
+- src/Domain/Asset/Asset.php — persists chunkCount and updatedAt in the aggregate and enforces monotonic lifecycle timestamps.
+- src/Domain/Asset/AssetRepositoryInterface.php — adds account-scoped file-name search to the domain repository contract.
+- src/Domain/Asset/Exception/StaleAssetWriteException.php — defines the domain-owned exception for stale writes.
+- src/Domain/Asset/ValueObject/UploadTarget.php — narrows accepted local mock URLs to the agreed deterministic shape while keeping existing HTTPS and loopback rules.
+- migrations/20260401120000_create_assets_table.sql — bootstraps the assets table idempotently and enforces lifecycle constraints in MySQL.
+- src/Infrastructure/Persistence/MySQLAssetRepository.php — implements MySQL persistence, uploadId lookup, deterministic search, no-op identical save, and compare-and-swap stale-write protection.
+- src/Infrastructure/Storage/MockStorageAdapter.php — returns deterministic local upload targets without cloud storage.
+- docs/api/01-agree-api-schema.md — documents deterministic local mock upload targets for local development.
+- docs/adr/04-asset-domain-contracts.md — records lifecycle persistence rules, search semantics, and the local mock URL contract.
+- tests/Unit/Domain/Asset/AssetTest.php — covers lifecycle persistence fields and timestamp invariants in the aggregate.
+- tests/Integration/Infrastructure/Persistence/AssetsTableBootstrapTest.php — verifies the assets-table bootstrap migration and DB-level lifecycle constraints.
+- tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php — verifies MySQL persistence behavior, search ordering, idempotent save, and stale-write protection.
+- tests/Unit/Domain/Asset/ValueObject/UploadTargetTest.php — verifies the exact local mock target shape and existing transport security rules.
+- tests/Unit/Infrastructure/Storage/MockStorageAdapterTest.php — verifies deterministic local mock upload targets.
+
+## Validation
+
+- Targeted Asset domain unit tests passed.
+- Docker-backed assets-table bootstrap integration test passed.
+- Docker-backed MySQL repository integration test passed.
+- Targeted UploadTarget and MockStorageAdapter unit tests passed with 38 tests and 72 assertions.
+- Editor diagnostics were clean for the repaired PHP files.
+
+## Delivery Chunks
+
+- Lifecycle persistence model — extended the Asset aggregate and repository contract with persisted lifecycle fields and account-scoped search semantics.
+- Database bootstrap — added the idempotent assets-table migration and DB-level lifecycle constraints.
+- MySQL repository — implemented prepared-statement persistence, uploadId lookup, deterministic search, no-op identical save, and stale-write protection.
+- Local mock storage — tightened UploadTarget validation, added MockStorageAdapter, and documented deterministic local mock behavior.
+
+## Follow-up
+
+- Wire storage adapter selection through the application and GraphQL runtime path.
+- Run the full pre-merge quality gate end to end before merge if it has not already been covered elsewhere.

--- a/migrations/20260401120000_create_assets_table.sql
+++ b/migrations/20260401120000_create_assets_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS assets (
     id CHAR(36) NOT NULL,
     upload_id CHAR(36) NOT NULL,
-    account_id LONGTEXT NOT NULL,
+    account_id VARCHAR(255) NOT NULL,
     file_name LONGTEXT COLLATE utf8mb4_0900_ai_ci NOT NULL,
     mime_type LONGTEXT NOT NULL,
     status VARCHAR(32) NOT NULL,
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS assets (
     created_at DATETIME(6) NOT NULL,
     updated_at DATETIME(6) NOT NULL,
     PRIMARY KEY (id),
+    KEY idx_assets_account_id (account_id),
     UNIQUE KEY uq_assets_upload_id (upload_id),
     CONSTRAINT chk_assets_status CHECK (status IN ('PENDING', 'UPLOADED', 'FAILED')),
     CONSTRAINT chk_assets_chunk_count_positive CHECK (chunk_count >= 1),

--- a/migrations/20260401120000_create_assets_table.sql
+++ b/migrations/20260401120000_create_assets_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS assets (
+    id CHAR(36) NOT NULL,
+    upload_id CHAR(36) NOT NULL,
+    account_id LONGTEXT NOT NULL,
+    file_name LONGTEXT COLLATE utf8mb4_0900_ai_ci NOT NULL,
+    mime_type LONGTEXT NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    chunk_count INT UNSIGNED NOT NULL,
+    completion_proof LONGTEXT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_assets_upload_id (upload_id),
+    CONSTRAINT chk_assets_status CHECK (status IN ('PENDING', 'UPLOADED', 'FAILED')),
+    CONSTRAINT chk_assets_chunk_count_positive CHECK (chunk_count >= 1),
+    CONSTRAINT chk_assets_completion_proof_matches_status CHECK (
+        (status = 'UPLOADED' AND completion_proof IS NOT NULL AND completion_proof REGEXP '[^[:space:]]')
+        OR (status IN ('PENDING', 'FAILED') AND completion_proof IS NULL)
+    ),
+    CONSTRAINT chk_assets_updated_at_not_before_created_at CHECK (updated_at >= created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,5 +20,6 @@ nav:
   - Implementation Logs:
       - US-01 Agree API Schema: logs/01-agree-api-schema.md
       - US-02 Domain Model Core Objects: logs/02-domain-model-core-objects.md
+      - US-03 Data & Local Storage Setup: logs/03-data-local-storage-setup.md
 plugins:
   - search

--- a/src/Domain/Asset/Asset.php
+++ b/src/Domain/Asset/Asset.php
@@ -26,6 +26,7 @@ final class Asset
     private ?UploadCompletionProofValue $completionProof = null;
     private int $chunkCount;
     private DateTimeImmutable $createdAt;
+    private ClockInterface $clock;
     private DateTimeImmutable $updatedAt;
 
     private function __construct(
@@ -50,9 +51,15 @@ final class Asset
     /**
      * @throws AssetDomainException
      */
-    public static function createPending(UploadId $uploadId, AccountId $accountId, string $fileName, string $mimeType): self
-    {
-        $now = new DateTimeImmutable();
+    public static function createPending(
+        UploadId $uploadId,
+        AccountId $accountId,
+        string $fileName,
+        string $mimeType,
+        ?ClockInterface $clock = null,
+    ): self {
+        $resolvedClock = $clock ?? new SystemClock();
+        $now = $resolvedClock->now();
 
         $asset = new self(
             id: AssetId::generate(),
@@ -62,6 +69,7 @@ final class Asset
             mimeType: $mimeType,
             status: AssetStatus::PENDING,
         );
+        $asset->clock = $resolvedClock;
 
         $asset->initializeLifecycleState($now, self::DEFAULT_CHUNK_COUNT);
 
@@ -93,6 +101,7 @@ final class Asset
             mimeType: $mimeType,
             status: $status,
         );
+        $asset->clock = new SystemClock();
 
         $asset->initializeLifecycleState(
             $persistedState['createdAt'],
@@ -126,6 +135,7 @@ final class Asset
             status: AssetStatus::UPLOADED,
             completionProof: $completionProof,
         );
+        $asset->clock = new SystemClock();
 
         $asset->initializeLifecycleState(
             $persistedState['createdAt'],
@@ -202,7 +212,7 @@ final class Asset
 
         $this->completionProof = $completionProof;
         $this->status = AssetStatus::UPLOADED;
-        $nextUpdatedAt = new DateTimeImmutable();
+        $nextUpdatedAt = $this->clock->now();
 
         if ($nextUpdatedAt > $this->updatedAt) {
             $this->updatedAt = $nextUpdatedAt;
@@ -223,7 +233,7 @@ final class Asset
         }
 
         $this->status = AssetStatus::FAILED;
-        $nextUpdatedAt = new DateTimeImmutable();
+        $nextUpdatedAt = $this->clock->now();
 
         if ($nextUpdatedAt > $this->updatedAt) {
             $this->updatedAt = $nextUpdatedAt;

--- a/src/Domain/Asset/Asset.php
+++ b/src/Domain/Asset/Asset.php
@@ -13,6 +13,10 @@ use DateTimeImmutable;
 
 final class Asset
 {
+    private const DEFAULT_CHUNK_COUNT = 1;
+    private const INVALID_CHUNK_COUNT_MESSAGE = 'Chunk count must be at least 1';
+    private const INVALID_UPDATED_AT_MESSAGE = 'Updated at must not be earlier than created at';
+
     private AssetId $id;
     private UploadId $uploadId;
     private AccountId $accountId;
@@ -20,7 +24,9 @@ final class Asset
     private string $mimeType;
     private AssetStatus $status;
     private ?UploadCompletionProofValue $completionProof = null;
+    private int $chunkCount;
     private DateTimeImmutable $createdAt;
+    private DateTimeImmutable $updatedAt;
 
     private function __construct(
         AssetId $id,
@@ -46,6 +52,8 @@ final class Asset
      */
     public static function createPending(UploadId $uploadId, AccountId $accountId, string $fileName, string $mimeType): self
     {
+        $now = new DateTimeImmutable();
+
         $asset = new self(
             id: AssetId::generate(),
             uploadId: $uploadId,
@@ -55,7 +63,7 @@ final class Asset
             status: AssetStatus::PENDING,
         );
 
-        $asset->createdAt = new DateTimeImmutable();
+        $asset->initializeLifecycleState($now, self::DEFAULT_CHUNK_COUNT);
 
         return $asset;
     }
@@ -63,6 +71,8 @@ final class Asset
     /**
      * Reconstitutes a non-uploaded Asset from persistence.
      * For UPLOADED status, use reconstituteUploaded() instead.
+     *
+     * @param array{createdAt: DateTimeImmutable, chunkCount?: int, updatedAt?: DateTimeImmutable} $persistedState
      *
      * @throws AssetDomainException
      */
@@ -73,7 +83,7 @@ final class Asset
         string $fileName,
         string $mimeType,
         AssetStatus $status,
-        DateTimeImmutable $createdAt,
+        array $persistedState,
     ): self {
         $asset = new self(
             id: $id,
@@ -84,12 +94,18 @@ final class Asset
             status: $status,
         );
 
-        $asset->createdAt = $createdAt;
+        $asset->initializeLifecycleState(
+            $persistedState['createdAt'],
+            $persistedState['chunkCount'] ?? self::DEFAULT_CHUNK_COUNT,
+            $persistedState['updatedAt'] ?? null,
+        );
 
         return $asset;
     }
 
     /**
+     * @param array{createdAt: DateTimeImmutable, chunkCount?: int, updatedAt?: DateTimeImmutable} $persistedState
+     *
      * @throws AssetDomainException
      */
     public static function reconstituteUploaded(
@@ -98,8 +114,8 @@ final class Asset
         AccountId $accountId,
         string $fileName,
         string $mimeType,
-        DateTimeImmutable $createdAt,
         UploadCompletionProofValue $completionProof,
+        array $persistedState,
     ): self {
         $asset = new self(
             id: $id,
@@ -111,9 +127,36 @@ final class Asset
             completionProof: $completionProof,
         );
 
-        $asset->createdAt = $createdAt;
+        $asset->initializeLifecycleState(
+            $persistedState['createdAt'],
+            $persistedState['chunkCount'] ?? self::DEFAULT_CHUNK_COUNT,
+            $persistedState['updatedAt'] ?? null,
+        );
 
         return $asset;
+    }
+
+    /**
+     * @throws AssetDomainException
+     */
+    private function initializeLifecycleState(
+        DateTimeImmutable $createdAt,
+        int $chunkCount,
+        ?DateTimeImmutable $updatedAt = null,
+    ): void {
+        $updatedAt ??= $createdAt;
+
+        if ($chunkCount < self::DEFAULT_CHUNK_COUNT) {
+            throw new AssetDomainException(self::INVALID_CHUNK_COUNT_MESSAGE);
+        }
+
+        if ($updatedAt < $createdAt) {
+            throw new AssetDomainException(self::INVALID_UPDATED_AT_MESSAGE);
+        }
+
+        $this->chunkCount = $chunkCount;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -159,6 +202,11 @@ final class Asset
 
         $this->completionProof = $completionProof;
         $this->status = AssetStatus::UPLOADED;
+        $nextUpdatedAt = new DateTimeImmutable();
+
+        if ($nextUpdatedAt > $this->updatedAt) {
+            $this->updatedAt = $nextUpdatedAt;
+        }
     }
 
     /**
@@ -170,7 +218,16 @@ final class Asset
             throw new AssetDomainException('Cannot mark an uploaded asset as failed');
         }
 
+        if ($this->status === AssetStatus::FAILED) {
+            return;
+        }
+
         $this->status = AssetStatus::FAILED;
+        $nextUpdatedAt = new DateTimeImmutable();
+
+        if ($nextUpdatedAt > $this->updatedAt) {
+            $this->updatedAt = $nextUpdatedAt;
+        }
     }
 
     public function getId(): AssetId
@@ -208,9 +265,19 @@ final class Asset
         return $this->completionProof;
     }
 
+    public function getChunkCount(): int
+    {
+        return $this->chunkCount;
+    }
+
     public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
     }
 
     public function equals(Asset $other): bool

--- a/src/Domain/Asset/AssetRepositoryInterface.php
+++ b/src/Domain/Asset/AssetRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Asset;
 
+use App\Domain\Asset\ValueObject\AccountId;
 use App\Domain\Asset\ValueObject\AssetId;
 use App\Domain\Asset\ValueObject\UploadId;
 
@@ -14,4 +15,14 @@ interface AssetRepositoryInterface
     public function findById(AssetId $assetId): ?Asset;
 
     public function findByUploadId(UploadId $uploadId): ?Asset;
+
+    /**
+    * Performs an account-scoped search using the trimmed query as a plain-text,
+    * case-insensitive substring match against fileName.
+    * Results are ordered by createdAt descending, then id ascending.
+    * Implementations must return an empty list when the trimmed query is empty.
+    *
+    * @return list<Asset>
+    */
+    public function searchByFileName(AccountId $accountId, string $query): array;
 }

--- a/src/Domain/Asset/AssetRepositoryInterface.php
+++ b/src/Domain/Asset/AssetRepositoryInterface.php
@@ -17,12 +17,12 @@ interface AssetRepositoryInterface
     public function findByUploadId(UploadId $uploadId): ?Asset;
 
     /**
-    * Performs an account-scoped search using the trimmed query as a plain-text,
-    * case-insensitive substring match against fileName.
-    * Results are ordered by createdAt descending, then id ascending.
-    * Implementations must return an empty list when the trimmed query is empty.
-    *
-    * @return list<Asset>
-    */
+     * Performs an account-scoped search using the trimmed query as a plain-text,
+     * case-insensitive substring match against fileName.
+     * Results are ordered by createdAt descending, then id ascending.
+     * Implementations must return an empty list when the trimmed query is empty.
+     *
+     * @return list<Asset>
+     */
     public function searchByFileName(AccountId $accountId, string $query): array;
 }

--- a/src/Domain/Asset/ClockInterface.php
+++ b/src/Domain/Asset/ClockInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Asset;
+
+use DateTimeImmutable;
+
+interface ClockInterface
+{
+    public function now(): DateTimeImmutable;
+}

--- a/src/Domain/Asset/Exception/StaleAssetWriteException.php
+++ b/src/Domain/Asset/Exception/StaleAssetWriteException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Asset\Exception;
+
+use RuntimeException;
+
+final class StaleAssetWriteException extends RuntimeException
+{
+}

--- a/src/Domain/Asset/SystemClock.php
+++ b/src/Domain/Asset/SystemClock.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Asset;
+
+use DateTimeImmutable;
+
+final class SystemClock implements ClockInterface
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/Domain/Asset/ValueObject/UploadId.php
+++ b/src/Domain/Asset/ValueObject/UploadId.php
@@ -8,12 +8,17 @@ final readonly class UploadId
 {
     private const UUID_PATTERN = '/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/';
 
+    public static function isValid(string $value): bool
+    {
+        return preg_match(self::UUID_PATTERN, $value) === 1;
+    }
+
     /**
      * @throws \InvalidArgumentException
      */
     public function __construct(public string $value)
     {
-        if (! preg_match(self::UUID_PATTERN, $value)) {
+        if (! self::isValid($value)) {
             throw new \InvalidArgumentException('Invalid UploadId format');
         }
     }

--- a/src/Domain/Asset/ValueObject/UploadTarget.php
+++ b/src/Domain/Asset/ValueObject/UploadTarget.php
@@ -10,6 +10,16 @@ use InvalidArgumentException;
 
 final readonly class UploadTarget
 {
+    private const ALLOWED_LOCAL_DEVELOPMENT_HOSTS = ['localhost', '127.0.0.1', '::1'];
+    private const EMPTY_URL_MESSAGE = 'Upload target URL cannot be empty';
+    private const INVALID_ABSOLUTE_URL_MESSAGE = 'Upload target URL must be a valid absolute URL';
+    private const LOCAL_DEVELOPMENT_MOCK_CHUNK_INDEX = '0';
+    private const LOCAL_DEVELOPMENT_MOCK_CHUNK_SEGMENT = 'chunk';
+    private const LOCAL_DEVELOPMENT_MOCK_HOST = 'uploads';
+    private const LOCAL_DEVELOPMENT_MOCK_PATH_SEGMENT_COUNT = 4;
+    private const MISSING_HOST_MESSAGE = 'Upload target URL must be an absolute URL with a host';
+    private const TRANSPORT_SECURITY_MESSAGE = 'Upload target URL must use HTTPS, except http://localhost, http://127.0.0.1, http://[::1], or mock://uploads for local development';
+
     public string $url;
     /**
      * @var list<UploadParameter>
@@ -58,34 +68,77 @@ final readonly class UploadTarget
     {
         $normalizedUrl = trim($url);
 
-        if ($normalizedUrl === '') {
-            throw new InvalidArgumentException('Upload target URL cannot be empty');
-        }
+        self::assertUrlIsNotEmpty($normalizedUrl);
+        self::assertUrlDoesNotContainWhitespace($normalizedUrl);
 
-        $parsedUrl = parse_url($normalizedUrl);
-
-        if (
-            ! is_array($parsedUrl)
-            || ! isset($parsedUrl['scheme'], $parsedUrl['host'])
-            || trim($parsedUrl['host']) === ''
-        ) {
-            throw new InvalidArgumentException('Upload target URL must be an absolute URL with a host');
-        }
-
-        if (filter_var($normalizedUrl, FILTER_VALIDATE_URL) === false) {
-            throw new InvalidArgumentException('Upload target URL must be a valid absolute URL');
-        }
+        $parsedUrl = self::parseAbsoluteUrl($normalizedUrl);
 
         $scheme = strtolower($parsedUrl['scheme']);
         $rawHost = $parsedUrl['host'];
         $host = strtolower(trim($rawHost, '[]'));
 
-        if ($scheme !== 'https' && ! self::isAllowedLocalDevelopmentUrl($scheme, $host)) {
-            throw new InvalidArgumentException(
-                'Upload target URL must use HTTPS, except http://localhost, http://127.0.0.1, or http://[::1] for local development'
-            );
+        self::assertTransportSecurity($normalizedUrl, $parsedUrl, $scheme, $host);
+
+        return self::rebuildNormalizedUrl($parsedUrl, $scheme, $host);
+    }
+
+    private static function assertUrlIsNotEmpty(string $url): void
+    {
+        if ($url === '') {
+            throw new InvalidArgumentException(self::EMPTY_URL_MESSAGE);
+        }
+    }
+
+    private static function assertUrlDoesNotContainWhitespace(string $url): void
+    {
+        if (preg_match('/\s/', $url) === 1) {
+            throw new InvalidArgumentException(self::INVALID_ABSOLUTE_URL_MESSAGE);
+        }
+    }
+
+    /**
+     * @return array{scheme: string, host: string, user?: string, pass?: string, port?: int, path?: string, query?: string, fragment?: string}
+     */
+    private static function parseAbsoluteUrl(string $url): array
+    {
+        $parsedUrl = parse_url($url);
+
+        if (
+            ! is_array($parsedUrl)
+            || ! isset($parsedUrl['scheme'], $parsedUrl['host'])
+            || trim((string) $parsedUrl['host']) === ''
+        ) {
+            throw new InvalidArgumentException(self::MISSING_HOST_MESSAGE);
         }
 
+        return $parsedUrl;
+    }
+
+    /**
+     * @param array{scheme: string, host: string, user?: string, pass?: string, port?: int, path?: string, query?: string, fragment?: string} $parsedUrl
+     */
+    private static function assertTransportSecurity(string $url, array $parsedUrl, string $scheme, string $host): void
+    {
+        if ($scheme === 'mock') {
+            self::assertAllowedLocalDevelopmentMockUrl($parsedUrl, $host);
+
+            return;
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException(self::INVALID_ABSOLUTE_URL_MESSAGE);
+        }
+
+        if ($scheme !== 'https' && ! self::isAllowedLocalDevelopmentUrl($scheme, $host)) {
+            throw new InvalidArgumentException(self::TRANSPORT_SECURITY_MESSAGE);
+        }
+    }
+
+    /**
+     * @param array{scheme: string, host: string, user?: string, pass?: string, port?: int, path?: string, query?: string, fragment?: string} $parsedUrl
+     */
+    private static function rebuildNormalizedUrl(array $parsedUrl, string $scheme, string $host): string
+    {
         // Reconstruct the URL using the lowercased scheme and host while preserving
         // original user/pass, port (only if present), path, query and fragment
         $auth = '';
@@ -110,12 +163,59 @@ final readonly class UploadTarget
         return $scheme . '://' . $auth . $hostForUrl . $port . $path . $query . $fragment;
     }
 
+    /**
+     * @param array{path?: mixed, user?: mixed, pass?: mixed, port?: mixed, query?: mixed, fragment?: mixed} $parsedUrl
+     */
+    private static function assertAllowedLocalDevelopmentMockUrl(array $parsedUrl, string $host): void
+    {
+        $path = $parsedUrl['path'] ?? null;
+
+        if (
+            $host !== self::LOCAL_DEVELOPMENT_MOCK_HOST
+            || isset($parsedUrl['user'])
+            || isset($parsedUrl['pass'])
+            || isset($parsedUrl['port'])
+            || isset($parsedUrl['query'])
+            || isset($parsedUrl['fragment'])
+            || ! is_string($path)
+            || ! self::isAllowedLocalDevelopmentMockPath($path)
+        ) {
+            throw new InvalidArgumentException(self::TRANSPORT_SECURITY_MESSAGE);
+        }
+    }
+
+    private static function isAllowedLocalDevelopmentMockPath(string $path): bool
+    {
+        $segments = explode('/', $path);
+
+        if (count($segments) !== self::LOCAL_DEVELOPMENT_MOCK_PATH_SEGMENT_COUNT) {
+            return false;
+        }
+
+        [$leadingSlash, $uploadId, $chunkSegment, $chunkIndex] = $segments;
+
+        if (
+            $leadingSlash !== ''
+            || $chunkSegment !== self::LOCAL_DEVELOPMENT_MOCK_CHUNK_SEGMENT
+            || $chunkIndex !== self::LOCAL_DEVELOPMENT_MOCK_CHUNK_INDEX
+        ) {
+            return false;
+        }
+
+        return self::isValidMockUploadId($uploadId);
+    }
+
+    private static function isValidMockUploadId(string $uploadId): bool
+    {
+        return UploadId::isValid($uploadId);
+    }
+
     private static function isAllowedLocalDevelopmentUrl(string $scheme, string $host): bool
     {
         if ($scheme !== 'http') {
             return false;
         }
 
-        return in_array($host, ['localhost', '127.0.0.1', '::1'], true);
+        return in_array($host, self::ALLOWED_LOCAL_DEVELOPMENT_HOSTS, true);
     }
 }

--- a/src/Infrastructure/Persistence/MySQLAssetRepository.php
+++ b/src/Infrastructure/Persistence/MySQLAssetRepository.php
@@ -193,6 +193,7 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
 
     private function updateMutableFields(Asset $asset, Asset $persistedAsset): void
     {
+        $parameters = $this->mutableUpdateParameters($asset, $persistedAsset);
         $statement = $this->connection->prepare(
             'UPDATE assets
              SET status = :status,
@@ -203,9 +204,28 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
                AND status = :expected_status
                AND updated_at = :expected_updated_at',
         );
-        $statement->execute($this->mutableUpdateParameters($asset, $persistedAsset));
+        $statement->execute($parameters);
 
         if ($statement->rowCount() === 0) {
+            $currentAsset = $this->findById($asset->getId());
+
+            if (
+                $currentAsset !== null
+                && [
+                    'status' => $currentAsset->getStatus()->value,
+                    'chunk_count' => $currentAsset->getChunkCount(),
+                    'completion_proof' => $currentAsset->getCompletionProof()?->value,
+                    'updated_at' => $currentAsset->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
+                ] === [
+                    'status' => $parameters['status'],
+                    'chunk_count' => $parameters['chunk_count'],
+                    'completion_proof' => $parameters['completion_proof'],
+                    'updated_at' => $parameters['updated_at'],
+                ]
+            ) {
+                return;
+            }
+
             throw new StaleAssetWriteException(self::STALE_WRITE_MESSAGE);
         }
     }

--- a/src/Infrastructure/Persistence/MySQLAssetRepository.php
+++ b/src/Infrastructure/Persistence/MySQLAssetRepository.php
@@ -69,7 +69,23 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
                 :updated_at
             )',
         );
-        $statement->execute($this->assetParameters($asset));
+
+        try {
+            $statement->execute($this->assetParameters($asset));
+        } catch (\PDOException $exception) {
+            // If another process inserted the same id concurrently we may get a
+            // duplicate-key error. Re-read the row and treat identical
+            // rows as a successful idempotent save; otherwise rethrow.
+            if ($exception->getCode() === '23000') {
+                $persisted = $this->findById($asset->getId());
+
+                if ($persisted !== null && $this->assetParameters($asset) === $this->assetParameters($persisted)) {
+                    return;
+                }
+            }
+
+            throw $exception;
+        }
     }
 
     public function findById(AssetId $assetId): ?Asset
@@ -219,8 +235,8 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
             'status' => $asset->getStatus()->value,
             'chunk_count' => $asset->getChunkCount(),
             'completion_proof' => $asset->getCompletionProof()?->value,
-            'created_at' => $asset->getCreatedAt()->format(self::DATETIME_FORMAT),
-            'updated_at' => $asset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+            'created_at' => $asset->getCreatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
+            'updated_at' => $asset->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
         ];
     }
 
@@ -242,7 +258,7 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
             'account_id' => (string) $asset->getAccountId(),
             'file_name' => $asset->getFileName(),
             'mime_type' => $asset->getMimeType(),
-            'created_at' => $asset->getCreatedAt()->format(self::DATETIME_FORMAT),
+            'created_at' => $asset->getCreatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
         ];
     }
 
@@ -264,9 +280,9 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
             'status' => $asset->getStatus()->value,
             'chunk_count' => $asset->getChunkCount(),
             'completion_proof' => $asset->getCompletionProof()?->value,
-            'updated_at' => $asset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+            'updated_at' => $asset->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
             'expected_status' => $persistedAsset->getStatus()->value,
-            'expected_updated_at' => $persistedAsset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+            'expected_updated_at' => $persistedAsset->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
         ];
     }
 
@@ -334,7 +350,7 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
 
     private function parseDateTime(string $value, string $column): DateTimeImmutable
     {
-        $dateTime = DateTimeImmutable::createFromFormat(self::DATETIME_FORMAT, $value);
+        $dateTime = DateTimeImmutable::createFromFormat(self::DATETIME_FORMAT, $value, new \DateTimeZone('UTC'));
 
         if (! $dateTime instanceof DateTimeImmutable) {
             throw new UnexpectedValueException(sprintf('Unexpected %s value.', $column));

--- a/src/Infrastructure/Persistence/MySQLAssetRepository.php
+++ b/src/Infrastructure/Persistence/MySQLAssetRepository.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence;
+
+use App\Domain\Asset\Asset;
+use App\Domain\Asset\AssetRepositoryInterface;
+use App\Domain\Asset\AssetStatus;
+use App\Domain\Asset\Exception\StaleAssetWriteException;
+use App\Domain\Asset\ValueObject\AccountId;
+use App\Domain\Asset\ValueObject\AssetId;
+use App\Domain\Asset\ValueObject\UploadCompletionProofValue;
+use App\Domain\Asset\ValueObject\UploadId;
+use DateTimeImmutable;
+use PDO;
+use UnexpectedValueException;
+
+final class MySQLAssetRepository implements AssetRepositoryInterface
+{
+    private const DATETIME_FORMAT = 'Y-m-d H:i:s.u';
+    private const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
+    private const LIKE_ESCAPE_CHARACTER = '!';
+    private const STALE_WRITE_MESSAGE = 'Cannot save stale asset state.';
+    private const UNEXPECTED_ROW_SHAPE_MESSAGE = 'Unexpected asset row shape.';
+
+    public function __construct(
+        private readonly PDO $connection,
+    ) {
+    }
+
+    public function save(Asset $asset): void
+    {
+        $persistedAsset = $this->findById($asset->getId());
+
+        if ($persistedAsset !== null) {
+            if ($this->assetParameters($asset) === $this->assetParameters($persistedAsset)) {
+                return;
+            }
+
+            $this->assertSafeUpdate($asset, $persistedAsset);
+            $this->updateMutableFields($asset, $persistedAsset);
+
+            return;
+        }
+
+        $statement = $this->connection->prepare(
+            'INSERT INTO assets (
+                id,
+                upload_id,
+                account_id,
+                file_name,
+                mime_type,
+                status,
+                chunk_count,
+                completion_proof,
+                created_at,
+                updated_at
+            ) VALUES (
+                :id,
+                :upload_id,
+                :account_id,
+                :file_name,
+                :mime_type,
+                :status,
+                :chunk_count,
+                :completion_proof,
+                :created_at,
+                :updated_at
+            )',
+        );
+        $statement->execute($this->assetParameters($asset));
+    }
+
+    public function findById(AssetId $assetId): ?Asset
+    {
+        return $this->findOne(
+            'SELECT id, upload_id, account_id, file_name, mime_type, status, chunk_count, completion_proof, created_at, updated_at
+             FROM assets
+             WHERE id = :id
+             LIMIT 1',
+            [
+                'id' => (string) $assetId,
+            ],
+        );
+    }
+
+    public function findByUploadId(UploadId $uploadId): ?Asset
+    {
+        return $this->findOne(
+            'SELECT id, upload_id, account_id, file_name, mime_type, status, chunk_count, completion_proof, created_at, updated_at
+             FROM assets
+             WHERE upload_id = :upload_id
+             LIMIT 1',
+            [
+                'upload_id' => (string) $uploadId,
+            ],
+        );
+    }
+
+    /**
+     * @return list<Asset>
+     */
+    public function searchByFileName(AccountId $accountId, string $query): array
+    {
+        $trimmedQuery = trim($query);
+
+        if ($trimmedQuery === '') {
+            return [];
+        }
+
+        $statement = $this->connection->prepare(sprintf(
+            "SELECT id, upload_id, account_id, file_name, mime_type, status, chunk_count, completion_proof, created_at, updated_at
+                         FROM assets
+                         WHERE account_id = :account_id
+                             AND file_name COLLATE %s LIKE :file_name_query ESCAPE '%s'
+                         ORDER BY created_at DESC, id ASC",
+            self::FILE_NAME_COLLATION,
+            self::LIKE_ESCAPE_CHARACTER,
+        ));
+        $statement->execute([
+            'account_id' => (string) $accountId,
+            'file_name_query' => '%' . $this->escapeLikePattern($trimmedQuery) . '%',
+        ]);
+
+        $assets = [];
+
+        while (($row = $statement->fetch(PDO::FETCH_ASSOC)) !== false) {
+            if (! is_array($row)) {
+                throw new UnexpectedValueException(self::UNEXPECTED_ROW_SHAPE_MESSAGE);
+            }
+
+            $assets[] = $this->mapAsset($row);
+        }
+
+        return $assets;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function findOne(string $sql, array $parameters): ?Asset
+    {
+        $statement = $this->connection->prepare($sql);
+        $statement->execute($parameters);
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        if (! is_array($row)) {
+            throw new UnexpectedValueException(self::UNEXPECTED_ROW_SHAPE_MESSAGE);
+        }
+
+        return $this->mapAsset($row);
+    }
+
+    private function assertSafeUpdate(Asset $asset, Asset $persistedAsset): void
+    {
+        if ($this->immutableAssetParameters($asset) !== $this->immutableAssetParameters($persistedAsset)) {
+            throw new StaleAssetWriteException(self::STALE_WRITE_MESSAGE);
+        }
+
+        if ($persistedAsset->getStatus() !== AssetStatus::PENDING) {
+            throw new StaleAssetWriteException(self::STALE_WRITE_MESSAGE);
+        }
+
+        if ($asset->getStatus() === AssetStatus::PENDING) {
+            throw new StaleAssetWriteException(self::STALE_WRITE_MESSAGE);
+        }
+
+        if ($asset->getUpdatedAt() < $persistedAsset->getUpdatedAt()) {
+            throw new StaleAssetWriteException(self::STALE_WRITE_MESSAGE);
+        }
+    }
+
+    private function updateMutableFields(Asset $asset, Asset $persistedAsset): void
+    {
+        $statement = $this->connection->prepare(
+            'UPDATE assets
+             SET status = :status,
+                 chunk_count = :chunk_count,
+                 completion_proof = :completion_proof,
+                 updated_at = :updated_at
+             WHERE id = :id
+               AND status = :expected_status
+               AND updated_at = :expected_updated_at',
+        );
+        $statement->execute($this->mutableUpdateParameters($asset, $persistedAsset));
+
+        if ($statement->rowCount() === 0) {
+            throw new StaleAssetWriteException(self::STALE_WRITE_MESSAGE);
+        }
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     upload_id: string,
+     *     account_id: string,
+     *     file_name: string,
+     *     mime_type: string,
+     *     status: string,
+     *     chunk_count: int,
+     *     completion_proof: string|null,
+     *     created_at: string,
+     *     updated_at: string
+     * }
+     */
+    private function assetParameters(Asset $asset): array
+    {
+        return [
+            'id' => (string) $asset->getId(),
+            'upload_id' => (string) $asset->getUploadId(),
+            'account_id' => (string) $asset->getAccountId(),
+            'file_name' => $asset->getFileName(),
+            'mime_type' => $asset->getMimeType(),
+            'status' => $asset->getStatus()->value,
+            'chunk_count' => $asset->getChunkCount(),
+            'completion_proof' => $asset->getCompletionProof()?->value,
+            'created_at' => $asset->getCreatedAt()->format(self::DATETIME_FORMAT),
+            'updated_at' => $asset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     upload_id: string,
+     *     account_id: string,
+     *     file_name: string,
+     *     mime_type: string,
+     *     created_at: string
+     * }
+     */
+    private function immutableAssetParameters(Asset $asset): array
+    {
+        return [
+            'id' => (string) $asset->getId(),
+            'upload_id' => (string) $asset->getUploadId(),
+            'account_id' => (string) $asset->getAccountId(),
+            'file_name' => $asset->getFileName(),
+            'mime_type' => $asset->getMimeType(),
+            'created_at' => $asset->getCreatedAt()->format(self::DATETIME_FORMAT),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     status: string,
+     *     chunk_count: int,
+     *     completion_proof: string|null,
+     *     updated_at: string,
+     *     expected_status: string,
+     *     expected_updated_at: string
+     * }
+     */
+    private function mutableUpdateParameters(Asset $asset, Asset $persistedAsset): array
+    {
+        return [
+            'id' => (string) $asset->getId(),
+            'status' => $asset->getStatus()->value,
+            'chunk_count' => $asset->getChunkCount(),
+            'completion_proof' => $asset->getCompletionProof()?->value,
+            'updated_at' => $asset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+            'expected_status' => $persistedAsset->getStatus()->value,
+            'expected_updated_at' => $persistedAsset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapAsset(array $row): Asset
+    {
+        $id = $row['id'] ?? null;
+        $uploadId = $row['upload_id'] ?? null;
+        $accountId = $row['account_id'] ?? null;
+        $fileName = $row['file_name'] ?? null;
+        $mimeType = $row['mime_type'] ?? null;
+        $status = $row['status'] ?? null;
+        $chunkCount = $row['chunk_count'] ?? null;
+        $completionProof = $row['completion_proof'] ?? null;
+        $createdAt = $row['created_at'] ?? null;
+        $updatedAt = $row['updated_at'] ?? null;
+
+        if (
+            ! is_string($id)
+            || ! is_string($uploadId)
+            || ! is_string($accountId)
+            || ! is_string($fileName)
+            || ! is_string($mimeType)
+            || ! is_string($status)
+            || ! is_numeric($chunkCount)
+            || ($completionProof !== null && ! is_string($completionProof))
+            || ! is_string($createdAt)
+            || ! is_string($updatedAt)
+        ) {
+            throw new UnexpectedValueException(self::UNEXPECTED_ROW_SHAPE_MESSAGE);
+        }
+
+        $persistedState = [
+            'createdAt' => $this->parseDateTime($createdAt, 'created_at'),
+            'chunkCount' => (int) $chunkCount,
+            'updatedAt' => $this->parseDateTime($updatedAt, 'updated_at'),
+        ];
+
+        $assetStatus = AssetStatus::from($status);
+
+        return match ($assetStatus) {
+            AssetStatus::UPLOADED => Asset::reconstituteUploaded(
+                new AssetId($id),
+                new UploadId($uploadId),
+                new AccountId($accountId),
+                $fileName,
+                $mimeType,
+                $this->uploadedCompletionProofValue($completionProof),
+                $persistedState,
+            ),
+            AssetStatus::PENDING,
+            AssetStatus::FAILED => Asset::reconstitute(
+                new AssetId($id),
+                new UploadId($uploadId),
+                new AccountId($accountId),
+                $fileName,
+                $mimeType,
+                $assetStatus,
+                $persistedState,
+            ),
+        };
+    }
+
+    private function parseDateTime(string $value, string $column): DateTimeImmutable
+    {
+        $dateTime = DateTimeImmutable::createFromFormat(self::DATETIME_FORMAT, $value);
+
+        if (! $dateTime instanceof DateTimeImmutable) {
+            throw new UnexpectedValueException(sprintf('Unexpected %s value.', $column));
+        }
+
+        return $dateTime;
+    }
+
+    private function uploadedCompletionProofValue(mixed $completionProof): UploadCompletionProofValue
+    {
+        if (! is_string($completionProof)) {
+            throw new UnexpectedValueException('Uploaded assets must include a completion proof.');
+        }
+
+        return new UploadCompletionProofValue($completionProof);
+    }
+
+    private function escapeLikePattern(string $value): string
+    {
+        return str_replace(
+            [self::LIKE_ESCAPE_CHARACTER, '%', '_'],
+            [
+                self::LIKE_ESCAPE_CHARACTER . self::LIKE_ESCAPE_CHARACTER,
+                self::LIKE_ESCAPE_CHARACTER . '%',
+                self::LIKE_ESCAPE_CHARACTER . '_',
+            ],
+            $value,
+        );
+    }
+}

--- a/src/Infrastructure/Storage/MockStorageAdapter.php
+++ b/src/Infrastructure/Storage/MockStorageAdapter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Storage;
+
+use App\Domain\Asset\Asset;
+use App\Domain\Asset\StorageAdapterInterface;
+use App\Domain\Asset\UploadCompletionProofSource;
+use App\Domain\Asset\UploadHttpMethod;
+use App\Domain\Asset\ValueObject\UploadCompletionProof;
+use App\Domain\Asset\ValueObject\UploadTarget;
+use DateTimeImmutable;
+
+final class MockStorageAdapter implements StorageAdapterInterface
+{
+    private const CHUNK_INDEX = 0;
+    private const COMPLETION_PROOF_NAME = 'etag';
+    private const DETERMINISTIC_EXPIRY = '2100-01-01T00:00:00+00:00';
+    private const URL_TEMPLATE = 'mock://uploads/%s/chunk/%d';
+
+    public function createUploadTarget(Asset $asset): UploadTarget
+    {
+        return new UploadTarget(
+            sprintf(self::URL_TEMPLATE, (string) $asset->getUploadId(), self::CHUNK_INDEX),
+            UploadHttpMethod::PUT,
+            [],
+            new UploadCompletionProof(self::COMPLETION_PROOF_NAME, UploadCompletionProofSource::RESPONSE_HEADER),
+            new DateTimeImmutable(self::DETERMINISTIC_EXPIRY),
+        );
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableBootstrapTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableBootstrapTest.php
@@ -11,10 +11,12 @@ use PHPUnit\Framework\TestCase;
 
 final class AssetsTableBootstrapTest extends TestCase
 {
+    private const ACCOUNT_ID_INDEX_NAME = 'idx_assets_account_id';
     private const TABLE_NAME = 'assets';
     private const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
     private const LONG_TEXT_DATA_TYPE = 'longtext';
     private const MIGRATION_FILE = __DIR__ . '/../../../../migrations/20260401120000_create_assets_table.sql';
+    private const VARCHAR_DATA_TYPE = 'varchar';
 
     /**
      * @var list<string>
@@ -51,7 +53,7 @@ final class AssetsTableBootstrapTest extends TestCase
      * @var array<string, string>
      */
     private const WIDENED_TEXT_COLUMNS = [
-        'account_id' => self::LONG_TEXT_DATA_TYPE,
+        'account_id' => self::VARCHAR_DATA_TYPE,
         'file_name' => self::LONG_TEXT_DATA_TYPE,
         'mime_type' => self::LONG_TEXT_DATA_TYPE,
         'completion_proof' => self::LONG_TEXT_DATA_TYPE,
@@ -68,14 +70,17 @@ final class AssetsTableBootstrapTest extends TestCase
         // Arrange & Act
         $this->withTemporarySchema(function (PDO $connection): void {
             $firstRunColumns = $this->fetchColumnMetadata($connection);
+            $firstRunAccountIdIndex = $this->fetchIndexColumns($connection, self::ACCOUNT_ID_INDEX_NAME);
             $firstRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
 
             $connection->exec($this->migrationSql());
             $secondRunColumns = $this->fetchColumnMetadata($connection);
+            $secondRunAccountIdIndex = $this->fetchIndexColumns($connection, self::ACCOUNT_ID_INDEX_NAME);
             $secondRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
 
             // Assert
-            self::assertSame([], $this->missingRequiredColumns($firstRunColumns));
+            $missing = array_values(array_diff(self::REQUIRED_COLUMNS, array_keys($firstRunColumns)));
+            self::assertSame([], $missing, 'Missing required columns: ' . implode(', ', $missing));
 
             foreach (self::REQUIRED_NON_NULLABLE_COLUMNS as $columnName) {
                 self::assertSame('NO', $firstRunColumns[$columnName]['IS_NULLABLE']);
@@ -87,8 +92,10 @@ final class AssetsTableBootstrapTest extends TestCase
 
             self::assertSame('YES', $firstRunColumns['completion_proof']['IS_NULLABLE']);
             self::assertSame(self::FILE_NAME_COLLATION, $firstRunColumns['file_name']['COLLATION_NAME']);
+            self::assertSame(['account_id'], $firstRunAccountIdIndex);
             self::assertSame([['upload_id']], $firstRunUploadIdUniqueIndexes);
             self::assertSame($firstRunColumns, $secondRunColumns);
+            self::assertSame($firstRunAccountIdIndex, $secondRunAccountIdIndex);
             self::assertSame([['upload_id']], $secondRunUploadIdUniqueIndexes);
         });
     }
@@ -138,6 +145,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'Invalid status values must be rejected.',
                 $validPendingRow,
+                null,
+                'chk_assets_',
             );
 
             $this->assertInsertFails(
@@ -147,6 +156,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'chunk_count values below 1 must be rejected.',
                 $validPendingRow,
+                null,
+                'chk_assets_chunk_count_positive',
             );
 
             $this->assertInsertFails(
@@ -156,6 +167,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'Non-uploaded pending assets must not persist a completion proof.',
                 $validPendingRow,
+                null,
+                'chk_assets_completion_proof_matches_status',
             );
 
             $this->assertInsertFails(
@@ -165,6 +178,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'Non-uploaded failed assets must not persist a completion proof.',
                 $this->validFailedRow(),
+                null,
+                'chk_assets_completion_proof_matches_status',
             );
 
             $this->assertInsertFails(
@@ -174,6 +189,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'Uploaded assets must persist a completion proof.',
                 $this->validUploadedRow(),
+                null,
+                'chk_assets_completion_proof_matches_status',
             );
 
             $this->assertInsertFails(
@@ -183,6 +200,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'Whitespace-only completion proof values must be rejected for uploaded assets.',
                 $this->validUploadedRow(),
+                null,
+                'chk_assets_completion_proof_matches_status',
             );
 
             $this->assertInsertFails(
@@ -193,6 +212,8 @@ final class AssetsTableBootstrapTest extends TestCase
                 ],
                 'updated_at values earlier than created_at must be rejected.',
                 $validPendingRow,
+                null,
+                'chk_assets_updated_at_not_before_created_at',
             );
 
             $this->insertAssetRow($connection, $validPendingRow);
@@ -383,7 +404,7 @@ final class AssetsTableBootstrapTest extends TestCase
     }
 
     /**
-         * @return array<string, array{IS_NULLABLE: string, COLLATION_NAME: string|null, DATA_TYPE: string}>
+     * @return array<string, array{IS_NULLABLE: string, COLLATION_NAME: string|null, DATA_TYPE: string}>
      */
     private function fetchColumnMetadata(PDO $connection): array
     {
@@ -430,13 +451,43 @@ final class AssetsTableBootstrapTest extends TestCase
     }
 
     /**
-     * @param array<string, array{IS_NULLABLE: string, COLLATION_NAME: string|null, DATA_TYPE: string}> $columns
-     *
      * @return list<string>
      */
-    private function missingRequiredColumns(array $columns): array
+    private function fetchIndexColumns(PDO $connection, string $indexName): array
     {
-        return array_values(array_diff(self::REQUIRED_COLUMNS, array_keys($columns)));
+        $statement = $connection->prepare(
+            'SELECT COLUMN_NAME, SEQ_IN_INDEX
+             FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = :tableName
+               AND INDEX_NAME = :indexName
+             ORDER BY SEQ_IN_INDEX',
+        );
+        $statement->execute([
+            'tableName' => self::TABLE_NAME,
+            'indexName' => $indexName,
+        ]);
+
+        $indexColumns = [];
+
+        while (($row = $statement->fetch()) !== false) {
+            if (! is_array($row)) {
+                self::fail('Unexpected index metadata row shape.');
+            }
+
+            $columnName = $row['COLUMN_NAME'] ?? null;
+            $seqInIndex = $row['SEQ_IN_INDEX'] ?? null;
+
+            if (! is_string($columnName) || ! is_numeric($seqInIndex)) {
+                self::fail('Unexpected index metadata row shape.');
+            }
+
+            $indexColumns[(int) $seqInIndex] = $columnName;
+        }
+
+        ksort($indexColumns);
+
+        return array_values($indexColumns);
     }
 
     /**
@@ -527,14 +578,26 @@ final class AssetsTableBootstrapTest extends TestCase
      * @param array<string, int|string|null> $overrides
      * @param array<string, int|string|null>|null $baseRow
      */
-    private function assertInsertFails(PDO $connection, array $overrides, string $message, ?array $baseRow = null): void
-    {
+    private function assertInsertFails(
+        PDO $connection,
+        array $overrides,
+        string $message,
+        ?array $baseRow = null,
+        ?string $expectedSqlState = '23000',
+        ?string $expectedMessageFragment = null,
+    ): void {
         $row = array_replace($baseRow ?? $this->validPendingRow(), $overrides);
 
         try {
             $this->insertAssetRow($connection, $row);
-        } catch (PDOException) {
-            $this->addToAssertionCount(1);
+        } catch (PDOException $exception) {
+            if ($expectedMessageFragment !== null) {
+                self::assertStringContainsString($expectedMessageFragment, $exception->getMessage());
+
+                return;
+            }
+
+            self::assertSame($expectedSqlState, $exception->getCode());
 
             return;
         }
@@ -595,7 +658,7 @@ final class AssetsTableBootstrapTest extends TestCase
         return [
             'id' => '11111111-1111-4111-8111-111111111111',
             'upload_id' => '22222222-2222-4222-8222-222222222222',
-            'account_id' => str_repeat('account-', 45),
+            'account_id' => str_repeat('account-', 20),
             'file_name' => str_repeat('very-long-file-name-', 18) . '.png',
             'mime_type' => 'application/' . str_repeat('vnd.example.long-subtype-', 12) . 'json',
             'status' => 'PENDING',

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableBootstrapTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableBootstrapTest.php
@@ -1,0 +1,648 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Persistence;
+
+use PDO;
+use PDOException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AssetsTableBootstrapTest extends TestCase
+{
+    private const TABLE_NAME = 'assets';
+    private const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
+    private const LONG_TEXT_DATA_TYPE = 'longtext';
+    private const MIGRATION_FILE = __DIR__ . '/../../../../migrations/20260401120000_create_assets_table.sql';
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_COLUMNS = [
+        'id',
+        'upload_id',
+        'account_id',
+        'file_name',
+        'mime_type',
+        'status',
+        'chunk_count',
+        'completion_proof',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const REQUIRED_NON_NULLABLE_COLUMNS = [
+        'id',
+        'upload_id',
+        'account_id',
+        'file_name',
+        'mime_type',
+        'status',
+        'chunk_count',
+        'created_at',
+        'updated_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const WIDENED_TEXT_COLUMNS = [
+        'account_id' => self::LONG_TEXT_DATA_TYPE,
+        'file_name' => self::LONG_TEXT_DATA_TYPE,
+        'mime_type' => self::LONG_TEXT_DATA_TYPE,
+        'completion_proof' => self::LONG_TEXT_DATA_TYPE,
+    ];
+
+    /**
+     * @var array{host: string, port: int, user: string, password: string}|null
+     */
+    private ?array $selectedConnection = null;
+
+    #[Test]
+    public function itCreatesTheExpectedAssetsTableSchemaAndCanBeReappliedSafely(): void
+    {
+        // Arrange & Act
+        $this->withTemporarySchema(function (PDO $connection): void {
+            $firstRunColumns = $this->fetchColumnMetadata($connection);
+            $firstRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
+
+            $connection->exec($this->migrationSql());
+            $secondRunColumns = $this->fetchColumnMetadata($connection);
+            $secondRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
+
+            // Assert
+            self::assertSame([], $this->missingRequiredColumns($firstRunColumns));
+
+            foreach (self::REQUIRED_NON_NULLABLE_COLUMNS as $columnName) {
+                self::assertSame('NO', $firstRunColumns[$columnName]['IS_NULLABLE']);
+            }
+
+            foreach (self::WIDENED_TEXT_COLUMNS as $columnName => $expectedDataType) {
+                self::assertSame($expectedDataType, $firstRunColumns[$columnName]['DATA_TYPE']);
+            }
+
+            self::assertSame('YES', $firstRunColumns['completion_proof']['IS_NULLABLE']);
+            self::assertSame(self::FILE_NAME_COLLATION, $firstRunColumns['file_name']['COLLATION_NAME']);
+            self::assertSame([['upload_id']], $firstRunUploadIdUniqueIndexes);
+            self::assertSame($firstRunColumns, $secondRunColumns);
+            self::assertSame([['upload_id']], $secondRunUploadIdUniqueIndexes);
+        });
+    }
+
+    #[Test]
+    public function itAcceptsRowsForEveryValidAssetLifecycleState(): void
+    {
+        // Arrange & Act
+        $this->withTemporarySchema(function (PDO $connection): void {
+            $validRows = [
+                $this->validPendingRow(),
+                $this->validFailedRow(),
+                $this->validUploadedRow(),
+            ];
+
+            foreach ($validRows as $row) {
+                $this->insertAssetRow($connection, $row);
+            }
+
+            // Assert
+            foreach ($validRows as $row) {
+                self::assertSame(
+                    [
+                        'status' => (string) $row['status'],
+                        'chunk_count' => (int) $row['chunk_count'],
+                        'completion_proof' => $row['completion_proof'] === null ? null : (string) $row['completion_proof'],
+                        'created_at' => (string) $row['created_at'],
+                        'updated_at' => (string) $row['updated_at'],
+                    ],
+                    $this->fetchPersistedLifecycleState($connection, (string) $row['upload_id']),
+                );
+            }
+        });
+    }
+
+    #[Test]
+    public function itRejectsRowsThatViolateAssetLifecycleConstraints(): void
+    {
+        // Arrange & Act
+        $this->withTemporarySchema(function (PDO $connection): void {
+            $validPendingRow = $this->validPendingRow();
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'status' => 'PROCESSING',
+                ],
+                'Invalid status values must be rejected.',
+                $validPendingRow,
+            );
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'chunk_count' => 0,
+                ],
+                'chunk_count values below 1 must be rejected.',
+                $validPendingRow,
+            );
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'completion_proof' => 'etag-pending-row',
+                ],
+                'Non-uploaded pending assets must not persist a completion proof.',
+                $validPendingRow,
+            );
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'completion_proof' => 'etag-failed-row',
+                ],
+                'Non-uploaded failed assets must not persist a completion proof.',
+                $this->validFailedRow(),
+            );
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'completion_proof' => null,
+                ],
+                'Uploaded assets must persist a completion proof.',
+                $this->validUploadedRow(),
+            );
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'completion_proof' => " \t\n ",
+                ],
+                'Whitespace-only completion proof values must be rejected for uploaded assets.',
+                $this->validUploadedRow(),
+            );
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'created_at' => '2026-04-01 12:00:01.000000',
+                    'updated_at' => '2026-04-01 12:00:00.000000',
+                ],
+                'updated_at values earlier than created_at must be rejected.',
+                $validPendingRow,
+            );
+
+            $this->insertAssetRow($connection, $validPendingRow);
+
+            $this->assertInsertFails(
+                $connection,
+                [
+                    'id' => '11111111-1111-4111-8111-111111111112',
+                    'file_name' => str_repeat('replacement-file-name-', 16) . '.png',
+                ],
+                'Duplicate upload_id values must be rejected.',
+                $validPendingRow,
+            );
+        });
+    }
+
+    /**
+     * @param callable(PDO): void $assertions
+     */
+    private function withTemporarySchema(callable $assertions): void
+    {
+        $serverConnection = $this->createServerConnectionOrSkip();
+        $databaseName = 'dam_schema_' . bin2hex(random_bytes(6));
+        $this->createDatabase($serverConnection, $databaseName);
+        $databaseConnection = null;
+
+        try {
+            $databaseConnection = $this->createDatabaseConnection($databaseName);
+            $databaseConnection->exec($this->migrationSql());
+
+            $assertions($databaseConnection);
+        } finally {
+            $databaseConnection = null;
+            $this->dropDatabase($serverConnection, $databaseName);
+        }
+    }
+
+    private function migrationSql(): string
+    {
+        $migrationSql = file_get_contents(self::MIGRATION_FILE);
+
+        if ($migrationSql === false) {
+            self::fail('Failed to read the assets table bootstrap migration.');
+        }
+
+        return $migrationSql;
+    }
+
+    private function createServerConnectionOrSkip(): PDO
+    {
+        if (! class_exists(PDO::class)) {
+            self::markTestSkipped('PDO is not available in this PHP runtime.');
+        }
+
+        $connectionErrors = [];
+
+        foreach ($this->connectionCandidates() as $candidate) {
+            $dsn = sprintf(
+                'mysql:host=%s;port=%d;charset=utf8mb4',
+                $candidate['host'],
+                $candidate['port'],
+            );
+
+            try {
+                $connection = $this->createConnection($dsn, $candidate['user'], $candidate['password']);
+                $this->selectedConnection = $candidate;
+
+                return $connection;
+            } catch (PDOException $exception) {
+                $connectionErrors[] = sprintf(
+                    '%s:%d (%s)',
+                    $candidate['host'],
+                    $candidate['port'],
+                    $exception->getMessage(),
+                );
+            }
+        }
+
+        self::markTestSkipped(
+            'MySQL is not reachable for integration tests. Tried: ' . implode('; ', $connectionErrors),
+        );
+    }
+
+    private function createDatabaseConnection(string $databaseName): PDO
+    {
+        if ($this->selectedConnection === null) {
+            self::fail('MySQL connection settings were not initialized.');
+        }
+
+        $dsn = sprintf(
+            'mysql:host=%s;port=%d;dbname=%s;charset=utf8mb4',
+            $this->selectedConnection['host'],
+            $this->selectedConnection['port'],
+            $databaseName,
+        );
+
+        return $this->createConnection($dsn, $this->selectedConnection['user'], $this->selectedConnection['password']);
+    }
+
+    private function createConnection(string $dsn, string $user, string $password): PDO
+    {
+        return new PDO(
+            $dsn,
+            $user,
+            $password,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ],
+        );
+    }
+
+    private function createDatabase(PDO $connection, string $databaseName): void
+    {
+        $connection->exec(
+            sprintf(
+                'CREATE DATABASE %s CHARACTER SET utf8mb4 COLLATE %s',
+                $this->quoteIdentifier($databaseName),
+                self::FILE_NAME_COLLATION,
+            ),
+        );
+    }
+
+    private function dropDatabase(PDO $connection, string $databaseName): void
+    {
+        $connection->exec('DROP DATABASE IF EXISTS ' . $this->quoteIdentifier($databaseName));
+    }
+
+    /**
+     * @return list<array{host: string, port: int, user: string, password: string}>
+     */
+    private function connectionCandidates(): array
+    {
+        $user = $this->env('DB_USER', 'root');
+        $password = $this->env('DB_PASSWORD', 'root');
+        $candidates = [[
+            'host' => $this->env('DB_HOST', '127.0.0.1'),
+            'port' => $this->envInt('DB_PORT', 3306),
+            'user' => $user,
+            'password' => $password,
+        ]];
+
+        $fallbackCandidate = [
+            'host' => '127.0.0.1',
+            'port' => $this->envInt('DB_HOST_PORT', 3307),
+            'user' => $user,
+            'password' => $password,
+        ];
+
+        if (
+            $fallbackCandidate['host'] !== $candidates[0]['host']
+            || $fallbackCandidate['port'] !== $candidates[0]['port']
+        ) {
+            $candidates[] = $fallbackCandidate;
+        }
+
+        return $candidates;
+    }
+
+    private function env(string $name, string $defaultValue): string
+    {
+        $value = getenv($name);
+
+        if ($value === false) {
+            return $defaultValue;
+        }
+
+        $trimmedValue = trim($value);
+
+        return $trimmedValue === '' ? $defaultValue : $trimmedValue;
+    }
+
+    private function envInt(string $name, int $defaultValue): int
+    {
+        $value = getenv($name);
+
+        if ($value === false) {
+            return $defaultValue;
+        }
+
+        $trimmedValue = trim($value);
+
+        if ($trimmedValue === '' || ! ctype_digit($trimmedValue)) {
+            return $defaultValue;
+        }
+
+        return (int) $trimmedValue;
+    }
+
+    /**
+         * @return array<string, array{IS_NULLABLE: string, COLLATION_NAME: string|null, DATA_TYPE: string}>
+     */
+    private function fetchColumnMetadata(PDO $connection): array
+    {
+        $statement = $connection->prepare(
+            'SELECT COLUMN_NAME, IS_NULLABLE, COLLATION_NAME, DATA_TYPE
+             FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = :tableName
+             ORDER BY ORDINAL_POSITION',
+        );
+        $statement->execute([
+            'tableName' => self::TABLE_NAME,
+        ]);
+
+        $columns = [];
+
+        while (($row = $statement->fetch()) !== false) {
+            if (! is_array($row)) {
+                self::fail('Unexpected column metadata row shape.');
+            }
+
+            $columnName = $row['COLUMN_NAME'] ?? null;
+            $isNullable = $row['IS_NULLABLE'] ?? null;
+            $collationName = $row['COLLATION_NAME'] ?? null;
+            $dataType = $row['DATA_TYPE'] ?? null;
+
+            if (
+                ! is_string($columnName)
+                || ! is_string($isNullable)
+                || ($collationName !== null && ! is_string($collationName))
+                || ! is_string($dataType)
+            ) {
+                self::fail('Unexpected column metadata row shape.');
+            }
+
+            $columns[$columnName] = [
+                'IS_NULLABLE' => $isNullable,
+                'COLLATION_NAME' => $collationName,
+                'DATA_TYPE' => $dataType,
+            ];
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param array<string, array{IS_NULLABLE: string, COLLATION_NAME: string|null, DATA_TYPE: string}> $columns
+     *
+     * @return list<string>
+     */
+    private function missingRequiredColumns(array $columns): array
+    {
+        return array_values(array_diff(self::REQUIRED_COLUMNS, array_keys($columns)));
+    }
+
+    /**
+     * @return list<list<string>>
+     */
+    private function fetchUniqueUploadIdIndexDefinitions(PDO $connection): array
+    {
+        $statement = $connection->prepare(
+            'SELECT INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX
+             FROM INFORMATION_SCHEMA.STATISTICS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME = :tableName
+               AND NON_UNIQUE = 0
+                             AND INDEX_NAME <> :primaryIndex
+                         ORDER BY INDEX_NAME, SEQ_IN_INDEX',
+        );
+        $statement->execute([
+            'tableName' => self::TABLE_NAME,
+            'primaryIndex' => 'PRIMARY',
+        ]);
+
+        $indexColumnsByName = [];
+
+        while (($row = $statement->fetch()) !== false) {
+            if (! is_array($row)) {
+                self::fail('Unexpected index metadata row shape.');
+            }
+
+            $indexName = $row['INDEX_NAME'] ?? null;
+            $columnName = $row['COLUMN_NAME'] ?? null;
+            $seqInIndex = $row['SEQ_IN_INDEX'] ?? null;
+
+            if (! is_string($indexName) || ! is_string($columnName) || ! is_numeric($seqInIndex)) {
+                self::fail('Unexpected index metadata row shape.');
+            }
+
+            $indexColumnsByName[$indexName][(int) $seqInIndex] = $columnName;
+        }
+
+        $uploadIdIndexes = [];
+
+        foreach ($indexColumnsByName as $columns) {
+            ksort($columns);
+            $orderedColumns = array_values($columns);
+
+            if (in_array('upload_id', $orderedColumns, true)) {
+                $uploadIdIndexes[] = $orderedColumns;
+            }
+        }
+
+        return $uploadIdIndexes;
+    }
+
+    /**
+     * @param array<string, int|string|null> $row
+     */
+    private function insertAssetRow(PDO $connection, array $row): void
+    {
+        $statement = $connection->prepare(
+            'INSERT INTO assets (
+                id,
+                upload_id,
+                account_id,
+                file_name,
+                mime_type,
+                status,
+                chunk_count,
+                completion_proof,
+                created_at,
+                updated_at
+            ) VALUES (
+                :id,
+                :upload_id,
+                :account_id,
+                :file_name,
+                :mime_type,
+                :status,
+                :chunk_count,
+                :completion_proof,
+                :created_at,
+                :updated_at
+            )',
+        );
+        $statement->execute($row);
+    }
+
+    /**
+     * @param array<string, int|string|null> $overrides
+     * @param array<string, int|string|null>|null $baseRow
+     */
+    private function assertInsertFails(PDO $connection, array $overrides, string $message, ?array $baseRow = null): void
+    {
+        $row = array_replace($baseRow ?? $this->validPendingRow(), $overrides);
+
+        try {
+            $this->insertAssetRow($connection, $row);
+        } catch (PDOException) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        self::fail($message);
+    }
+
+    /**
+     * @return array{status: string, chunk_count: int, completion_proof: string|null, created_at: string, updated_at: string}
+     */
+    private function fetchPersistedLifecycleState(PDO $connection, string $uploadId): array
+    {
+        $statement = $connection->prepare(
+            'SELECT status, chunk_count, completion_proof, created_at, updated_at
+             FROM assets
+             WHERE upload_id = :upload_id',
+        );
+        $statement->execute([
+            'upload_id' => $uploadId,
+        ]);
+
+        $row = $statement->fetch();
+
+        if (! is_array($row)) {
+            self::fail('Expected a persisted asset row for the supplied upload id.');
+        }
+
+        $status = $row['status'] ?? null;
+        $chunkCount = $row['chunk_count'] ?? null;
+        $completionProof = $row['completion_proof'] ?? null;
+        $createdAt = $row['created_at'] ?? null;
+        $updatedAt = $row['updated_at'] ?? null;
+
+        if (
+            ! is_string($status)
+            || ! is_numeric($chunkCount)
+            || ($completionProof !== null && ! is_string($completionProof))
+            || ! is_string($createdAt)
+            || ! is_string($updatedAt)
+        ) {
+            self::fail('Unexpected persisted asset row shape.');
+        }
+
+        return [
+            'status' => $status,
+            'chunk_count' => (int) $chunkCount,
+            'completion_proof' => $completionProof,
+            'created_at' => $createdAt,
+            'updated_at' => $updatedAt,
+        ];
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    private function validPendingRow(): array
+    {
+        return [
+            'id' => '11111111-1111-4111-8111-111111111111',
+            'upload_id' => '22222222-2222-4222-8222-222222222222',
+            'account_id' => str_repeat('account-', 45),
+            'file_name' => str_repeat('very-long-file-name-', 18) . '.png',
+            'mime_type' => 'application/' . str_repeat('vnd.example.long-subtype-', 12) . 'json',
+            'status' => 'PENDING',
+            'chunk_count' => 1,
+            'completion_proof' => null,
+            'created_at' => '2026-04-01 12:00:00.000000',
+            'updated_at' => '2026-04-01 12:00:00.000000',
+        ];
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    private function validFailedRow(): array
+    {
+        return array_replace(
+            $this->validPendingRow(),
+            [
+                'id' => '55555555-5555-4555-8555-555555555555',
+                'upload_id' => '66666666-6666-4666-8666-666666666666',
+                'status' => 'FAILED',
+                'chunk_count' => 2,
+                'updated_at' => '2026-04-01 12:03:00.000000',
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    private function validUploadedRow(): array
+    {
+        return array_replace(
+            $this->validPendingRow(),
+            [
+                'id' => '33333333-3333-4333-8333-333333333333',
+                'upload_id' => '44444444-4444-4444-8444-444444444444',
+                'status' => 'UPLOADED',
+                'chunk_count' => 3,
+                'completion_proof' => str_repeat('etag-', 80),
+                'updated_at' => '2026-04-01 12:05:00.000000',
+            ],
+        );
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Persistence;
+
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+final class AssetsTableLifecycleTest extends BaseAssetsTableTest
+{
+    #[Test]
+    #[DataProvider('provideValidLifecycleRows')]
+    public function itReturnsPersistedLifecycleStateWhenRowIsValid(string $rowType): void
+    {
+        // Arrange & Act
+        $this->withTemporarySchema(function (PDO $connection) use ($rowType): void {
+            $row = match ($rowType) {
+                'pending' => $this->validPendingRow(),
+                'failed' => $this->validFailedRow(),
+                'uploaded' => $this->validUploadedRow(),
+                default => throw new \UnexpectedValueException('Unknown lifecycle row type'),
+            };
+
+            $this->insertAssetRow($connection, $row);
+
+            // Assert
+            self::assertSame(
+                [
+                    'status' => (string) $row['status'],
+                    'chunk_count' => (int) $row['chunk_count'],
+                    'completion_proof' => $row['completion_proof'] === null ? null : (string) $row['completion_proof'],
+                    'created_at' => (string) $row['created_at'],
+                    'updated_at' => (string) $row['updated_at'],
+                ],
+                $this->fetchPersistedLifecycleState($connection, (string) $row['upload_id']),
+            );
+        });
+    }
+
+    /**
+     * @param array<string,int|string|null> $overrides
+     */
+    #[Test]
+    #[DataProvider('provideInvalidLifecycleCases')]
+    public function itThrowsConstraintViolationWhenRowInvalid(array $overrides, string $message, ?string $baseRowName = null, ?string $expectedSqlState = '23000', ?string $expectedMessageFragment = null, bool $preInsertBaseRow = false): void
+    {
+        // Arrange & Act
+        $this->withTemporarySchema(function (PDO $connection) use ($overrides, $message, $baseRowName, $expectedSqlState, $expectedMessageFragment, $preInsertBaseRow): void {
+            $baseRow = $baseRowName === null ? null : match ($baseRowName) {
+                'pending' => $this->validPendingRow(),
+                'failed' => $this->validFailedRow(),
+                'uploaded' => $this->validUploadedRow(),
+                default => null,
+            };
+
+            if ($preInsertBaseRow && $baseRow !== null) {
+                $this->insertAssetRow($connection, $baseRow);
+            }
+
+            $this->assertInsertFails(
+                $connection,
+                $overrides,
+                $message,
+                $baseRow,
+                $expectedSqlState,
+                $expectedMessageFragment,
+            );
+        });
+    }
+
+    /** @return list<array{string}> */
+    public static function provideValidLifecycleRows(): array
+    {
+        return [
+            ['pending'],
+            ['failed'],
+            ['uploaded'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{array<string,int|string|null>, string, ?string, ?string, ?string, bool}>
+     */
+    public static function provideInvalidLifecycleCases(): array
+    {
+        return [
+            'invalid status' => [
+                ['status' => 'PROCESSING'],
+                'Invalid status values must be rejected.',
+                'pending',
+                null,
+                'chk_assets_',
+                false,
+            ],
+            'chunk_count below one' => [
+                ['chunk_count' => 0],
+                'chunk_count values below 1 must be rejected.',
+                'pending',
+                null,
+                'chk_assets_chunk_count_positive',
+                false,
+            ],
+            'pending with completion proof' => [
+                ['completion_proof' => 'etag-pending-row'],
+                'Non-uploaded pending assets must not persist a completion proof.',
+                'pending',
+                null,
+                'chk_assets_completion_proof_matches_status',
+                false,
+            ],
+            'failed with completion proof' => [
+                ['completion_proof' => 'etag-failed-row'],
+                'Non-uploaded failed assets must not persist a completion proof.',
+                'failed',
+                null,
+                'chk_assets_completion_proof_matches_status',
+                false,
+            ],
+            'uploaded without completion proof' => [
+                ['completion_proof' => null],
+                'Uploaded assets must persist a completion proof.',
+                'uploaded',
+                null,
+                'chk_assets_completion_proof_matches_status',
+                false,
+            ],
+            'uploaded with whitespace completion proof' => [
+                ['completion_proof' => " \t\n "],
+                'Whitespace-only completion proof values must be rejected for uploaded assets.',
+                'uploaded',
+                null,
+                'chk_assets_completion_proof_matches_status',
+                false,
+            ],
+            'updated_at earlier than created_at' => [
+                [
+                    'created_at' => '2026-04-01 12:00:01.000000',
+                    'updated_at' => '2026-04-01 12:00:00.000000',
+                ],
+                'updated_at values earlier than created_at must be rejected.',
+                'pending',
+                null,
+                'chk_assets_updated_at_not_before_created_at',
+                false,
+            ],
+            'duplicate upload_id' => [
+                [
+                    'id' => '11111111-1111-4111-8111-111111111112',
+                    'file_name' => str_repeat('replacement-file-name-', 16) . '.png',
+                ],
+                'Duplicate upload_id values must be rejected.',
+                'pending',
+                '23000',
+                null,
+                true,
+            ],
+        ];
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
-final class AssetsTableLifecycleTest extends BaseAssetsTableTest
+final class AssetsTableLifecycleTest extends BaseAssetsTableTestCase
 {
     #[Test]
     #[DataProvider('provideValidLifecycleRows')]

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableSchemaTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableSchemaTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Test;
 final class AssetsTableSchemaTest extends BaseAssetsTableTestCase
 {
     #[Test]
-    public function itCreatesTheExpectedAssetsTableSchemaAndCanBeReappliedSafely(): void
+    public function itReturnsExpectedSchemaWhenReappliedSafely(): void
     {
         // Arrange & Act
         $this->withTemporarySchema(function (PDO $connection): void {

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableSchemaTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableSchemaTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Integration\Infrastructure\Persistence;
 use PDO;
 use PHPUnit\Framework\Attributes\Test;
 
-final class AssetsTableSchemaTest extends BaseAssetsTableTest
+final class AssetsTableSchemaTest extends BaseAssetsTableTestCase
 {
     #[Test]
     public function itCreatesTheExpectedAssetsTableSchemaAndCanBeReappliedSafely(): void

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableSchemaTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableSchemaTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Persistence;
+
+use PDO;
+use PHPUnit\Framework\Attributes\Test;
+
+final class AssetsTableSchemaTest extends BaseAssetsTableTest
+{
+    #[Test]
+    public function itCreatesTheExpectedAssetsTableSchemaAndCanBeReappliedSafely(): void
+    {
+        // Arrange & Act
+        $this->withTemporarySchema(function (PDO $connection): void {
+            $firstRunColumns = $this->fetchColumnMetadata($connection);
+            $firstRunAccountIdIndex = $this->fetchIndexColumns($connection, self::ACCOUNT_ID_INDEX_NAME);
+            $firstRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
+
+            $connection->exec($this->migrationSql());
+            $secondRunColumns = $this->fetchColumnMetadata($connection);
+            $secondRunAccountIdIndex = $this->fetchIndexColumns($connection, self::ACCOUNT_ID_INDEX_NAME);
+            $secondRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
+
+            // Assert
+            $missing = array_values(array_diff(self::REQUIRED_COLUMNS, array_keys($firstRunColumns)));
+            self::assertSame([], $missing, 'Missing required columns: ' . implode(', ', $missing));
+
+            foreach (self::REQUIRED_NON_NULLABLE_COLUMNS as $columnName) {
+                self::assertSame('NO', $firstRunColumns[$columnName]['IS_NULLABLE']);
+            }
+
+            foreach (self::WIDENED_TEXT_COLUMNS as $columnName => $expectedDataType) {
+                self::assertSame($expectedDataType, $firstRunColumns[$columnName]['DATA_TYPE']);
+            }
+
+            self::assertSame('YES', $firstRunColumns['completion_proof']['IS_NULLABLE']);
+            self::assertSame(self::FILE_NAME_COLLATION, $firstRunColumns['file_name']['COLLATION_NAME']);
+            self::assertSame(['account_id'], $firstRunAccountIdIndex);
+            self::assertSame([['upload_id']], $firstRunUploadIdUniqueIndexes);
+            self::assertSame($firstRunColumns, $secondRunColumns);
+            self::assertSame($firstRunAccountIdIndex, $secondRunAccountIdIndex);
+            self::assertSame([['upload_id']], $secondRunUploadIdUniqueIndexes);
+        });
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/BaseAssetsTableTest.php
+++ b/tests/Integration/Infrastructure/Persistence/BaseAssetsTableTest.php
@@ -6,22 +6,19 @@ namespace App\Tests\Integration\Infrastructure\Persistence;
 
 use PDO;
 use PDOException;
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-final class AssetsTableBootstrapTest extends TestCase
+abstract class BaseAssetsTableTest extends TestCase
 {
-    private const ACCOUNT_ID_INDEX_NAME = 'idx_assets_account_id';
-    private const TABLE_NAME = 'assets';
-    private const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
-    private const LONG_TEXT_DATA_TYPE = 'longtext';
-    private const MIGRATION_FILE = __DIR__ . '/../../../../migrations/20260401120000_create_assets_table.sql';
-    private const VARCHAR_DATA_TYPE = 'varchar';
+    protected const ACCOUNT_ID_INDEX_NAME = 'idx_assets_account_id';
+    protected const TABLE_NAME = 'assets';
+    protected const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
+    protected const LONG_TEXT_DATA_TYPE = 'longtext';
+    protected const MIGRATION_FILE = __DIR__ . '/../../../../migrations/20260401120000_create_assets_table.sql';
+    protected const VARCHAR_DATA_TYPE = 'varchar';
 
-    /**
-     * @var list<string>
-     */
-    private const REQUIRED_COLUMNS = [
+    /** @var list<string> */
+    protected const REQUIRED_COLUMNS = [
         'id',
         'upload_id',
         'account_id',
@@ -34,10 +31,8 @@ final class AssetsTableBootstrapTest extends TestCase
         'updated_at',
     ];
 
-    /**
-     * @var list<string>
-     */
-    private const REQUIRED_NON_NULLABLE_COLUMNS = [
+    /** @var list<string> */
+    protected const REQUIRED_NON_NULLABLE_COLUMNS = [
         'id',
         'upload_id',
         'account_id',
@@ -49,191 +44,21 @@ final class AssetsTableBootstrapTest extends TestCase
         'updated_at',
     ];
 
-    /**
-     * @var array<string, string>
-     */
-    private const WIDENED_TEXT_COLUMNS = [
+    /** @var array<string, string> */
+    protected const WIDENED_TEXT_COLUMNS = [
         'account_id' => self::VARCHAR_DATA_TYPE,
         'file_name' => self::LONG_TEXT_DATA_TYPE,
         'mime_type' => self::LONG_TEXT_DATA_TYPE,
         'completion_proof' => self::LONG_TEXT_DATA_TYPE,
     ];
 
-    /**
-     * @var array{host: string, port: int, user: string, password: string}|null
-     */
+    /** @var array{host: string, port: int, user: string, password: string}|null */
     private ?array $selectedConnection = null;
-
-    #[Test]
-    public function itCreatesTheExpectedAssetsTableSchemaAndCanBeReappliedSafely(): void
-    {
-        // Arrange & Act
-        $this->withTemporarySchema(function (PDO $connection): void {
-            $firstRunColumns = $this->fetchColumnMetadata($connection);
-            $firstRunAccountIdIndex = $this->fetchIndexColumns($connection, self::ACCOUNT_ID_INDEX_NAME);
-            $firstRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
-
-            $connection->exec($this->migrationSql());
-            $secondRunColumns = $this->fetchColumnMetadata($connection);
-            $secondRunAccountIdIndex = $this->fetchIndexColumns($connection, self::ACCOUNT_ID_INDEX_NAME);
-            $secondRunUploadIdUniqueIndexes = $this->fetchUniqueUploadIdIndexDefinitions($connection);
-
-            // Assert
-            $missing = array_values(array_diff(self::REQUIRED_COLUMNS, array_keys($firstRunColumns)));
-            self::assertSame([], $missing, 'Missing required columns: ' . implode(', ', $missing));
-
-            foreach (self::REQUIRED_NON_NULLABLE_COLUMNS as $columnName) {
-                self::assertSame('NO', $firstRunColumns[$columnName]['IS_NULLABLE']);
-            }
-
-            foreach (self::WIDENED_TEXT_COLUMNS as $columnName => $expectedDataType) {
-                self::assertSame($expectedDataType, $firstRunColumns[$columnName]['DATA_TYPE']);
-            }
-
-            self::assertSame('YES', $firstRunColumns['completion_proof']['IS_NULLABLE']);
-            self::assertSame(self::FILE_NAME_COLLATION, $firstRunColumns['file_name']['COLLATION_NAME']);
-            self::assertSame(['account_id'], $firstRunAccountIdIndex);
-            self::assertSame([['upload_id']], $firstRunUploadIdUniqueIndexes);
-            self::assertSame($firstRunColumns, $secondRunColumns);
-            self::assertSame($firstRunAccountIdIndex, $secondRunAccountIdIndex);
-            self::assertSame([['upload_id']], $secondRunUploadIdUniqueIndexes);
-        });
-    }
-
-    #[Test]
-    public function itAcceptsRowsForEveryValidAssetLifecycleState(): void
-    {
-        // Arrange & Act
-        $this->withTemporarySchema(function (PDO $connection): void {
-            $validRows = [
-                $this->validPendingRow(),
-                $this->validFailedRow(),
-                $this->validUploadedRow(),
-            ];
-
-            foreach ($validRows as $row) {
-                $this->insertAssetRow($connection, $row);
-            }
-
-            // Assert
-            foreach ($validRows as $row) {
-                self::assertSame(
-                    [
-                        'status' => (string) $row['status'],
-                        'chunk_count' => (int) $row['chunk_count'],
-                        'completion_proof' => $row['completion_proof'] === null ? null : (string) $row['completion_proof'],
-                        'created_at' => (string) $row['created_at'],
-                        'updated_at' => (string) $row['updated_at'],
-                    ],
-                    $this->fetchPersistedLifecycleState($connection, (string) $row['upload_id']),
-                );
-            }
-        });
-    }
-
-    #[Test]
-    public function itRejectsRowsThatViolateAssetLifecycleConstraints(): void
-    {
-        // Arrange & Act
-        $this->withTemporarySchema(function (PDO $connection): void {
-            $validPendingRow = $this->validPendingRow();
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'status' => 'PROCESSING',
-                ],
-                'Invalid status values must be rejected.',
-                $validPendingRow,
-                null,
-                'chk_assets_',
-            );
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'chunk_count' => 0,
-                ],
-                'chunk_count values below 1 must be rejected.',
-                $validPendingRow,
-                null,
-                'chk_assets_chunk_count_positive',
-            );
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'completion_proof' => 'etag-pending-row',
-                ],
-                'Non-uploaded pending assets must not persist a completion proof.',
-                $validPendingRow,
-                null,
-                'chk_assets_completion_proof_matches_status',
-            );
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'completion_proof' => 'etag-failed-row',
-                ],
-                'Non-uploaded failed assets must not persist a completion proof.',
-                $this->validFailedRow(),
-                null,
-                'chk_assets_completion_proof_matches_status',
-            );
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'completion_proof' => null,
-                ],
-                'Uploaded assets must persist a completion proof.',
-                $this->validUploadedRow(),
-                null,
-                'chk_assets_completion_proof_matches_status',
-            );
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'completion_proof' => " \t\n ",
-                ],
-                'Whitespace-only completion proof values must be rejected for uploaded assets.',
-                $this->validUploadedRow(),
-                null,
-                'chk_assets_completion_proof_matches_status',
-            );
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'created_at' => '2026-04-01 12:00:01.000000',
-                    'updated_at' => '2026-04-01 12:00:00.000000',
-                ],
-                'updated_at values earlier than created_at must be rejected.',
-                $validPendingRow,
-                null,
-                'chk_assets_updated_at_not_before_created_at',
-            );
-
-            $this->insertAssetRow($connection, $validPendingRow);
-
-            $this->assertInsertFails(
-                $connection,
-                [
-                    'id' => '11111111-1111-4111-8111-111111111112',
-                    'file_name' => str_repeat('replacement-file-name-', 16) . '.png',
-                ],
-                'Duplicate upload_id values must be rejected.',
-                $validPendingRow,
-            );
-        });
-    }
 
     /**
      * @param callable(PDO): void $assertions
      */
-    private function withTemporarySchema(callable $assertions): void
+    protected function withTemporarySchema(callable $assertions): void
     {
         $serverConnection = $this->createServerConnectionOrSkip();
         $databaseName = 'dam_schema_' . bin2hex(random_bytes(6));
@@ -251,7 +76,7 @@ final class AssetsTableBootstrapTest extends TestCase
         }
     }
 
-    private function migrationSql(): string
+    protected function migrationSql(): string
     {
         $migrationSql = file_get_contents(self::MIGRATION_FILE);
 
@@ -262,7 +87,7 @@ final class AssetsTableBootstrapTest extends TestCase
         return $migrationSql;
     }
 
-    private function createServerConnectionOrSkip(): PDO
+    protected function createServerConnectionOrSkip(): PDO
     {
         if (! class_exists(PDO::class)) {
             self::markTestSkipped('PDO is not available in this PHP runtime.');
@@ -297,7 +122,7 @@ final class AssetsTableBootstrapTest extends TestCase
         );
     }
 
-    private function createDatabaseConnection(string $databaseName): PDO
+    protected function createDatabaseConnection(string $databaseName): PDO
     {
         if ($this->selectedConnection === null) {
             self::fail('MySQL connection settings were not initialized.');
@@ -313,7 +138,7 @@ final class AssetsTableBootstrapTest extends TestCase
         return $this->createConnection($dsn, $this->selectedConnection['user'], $this->selectedConnection['password']);
     }
 
-    private function createConnection(string $dsn, string $user, string $password): PDO
+    protected function createConnection(string $dsn, string $user, string $password): PDO
     {
         return new PDO(
             $dsn,
@@ -326,7 +151,7 @@ final class AssetsTableBootstrapTest extends TestCase
         );
     }
 
-    private function createDatabase(PDO $connection, string $databaseName): void
+    protected function createDatabase(PDO $connection, string $databaseName): void
     {
         $connection->exec(
             sprintf(
@@ -337,7 +162,7 @@ final class AssetsTableBootstrapTest extends TestCase
         );
     }
 
-    private function dropDatabase(PDO $connection, string $databaseName): void
+    protected function dropDatabase(PDO $connection, string $databaseName): void
     {
         $connection->exec('DROP DATABASE IF EXISTS ' . $this->quoteIdentifier($databaseName));
     }
@@ -345,7 +170,7 @@ final class AssetsTableBootstrapTest extends TestCase
     /**
      * @return list<array{host: string, port: int, user: string, password: string}>
      */
-    private function connectionCandidates(): array
+    protected function connectionCandidates(): array
     {
         $user = $this->env('DB_USER', 'root');
         $password = $this->env('DB_PASSWORD', 'root');
@@ -373,7 +198,7 @@ final class AssetsTableBootstrapTest extends TestCase
         return $candidates;
     }
 
-    private function env(string $name, string $defaultValue): string
+    protected function env(string $name, string $defaultValue): string
     {
         $value = getenv($name);
 
@@ -386,7 +211,7 @@ final class AssetsTableBootstrapTest extends TestCase
         return $trimmedValue === '' ? $defaultValue : $trimmedValue;
     }
 
-    private function envInt(string $name, int $defaultValue): int
+    protected function envInt(string $name, int $defaultValue): int
     {
         $value = getenv($name);
 
@@ -406,7 +231,7 @@ final class AssetsTableBootstrapTest extends TestCase
     /**
      * @return array<string, array{IS_NULLABLE: string, COLLATION_NAME: string|null, DATA_TYPE: string}>
      */
-    private function fetchColumnMetadata(PDO $connection): array
+    protected function fetchColumnMetadata(PDO $connection): array
     {
         $statement = $connection->prepare(
             'SELECT COLUMN_NAME, IS_NULLABLE, COLLATION_NAME, DATA_TYPE
@@ -453,7 +278,7 @@ final class AssetsTableBootstrapTest extends TestCase
     /**
      * @return list<string>
      */
-    private function fetchIndexColumns(PDO $connection, string $indexName): array
+    protected function fetchIndexColumns(PDO $connection, string $indexName): array
     {
         $statement = $connection->prepare(
             'SELECT COLUMN_NAME, SEQ_IN_INDEX
@@ -493,7 +318,7 @@ final class AssetsTableBootstrapTest extends TestCase
     /**
      * @return list<list<string>>
      */
-    private function fetchUniqueUploadIdIndexDefinitions(PDO $connection): array
+    protected function fetchUniqueUploadIdIndexDefinitions(PDO $connection): array
     {
         $statement = $connection->prepare(
             'SELECT INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX
@@ -544,7 +369,7 @@ final class AssetsTableBootstrapTest extends TestCase
     /**
      * @param array<string, int|string|null> $row
      */
-    private function insertAssetRow(PDO $connection, array $row): void
+    protected function insertAssetRow(PDO $connection, array $row): void
     {
         $statement = $connection->prepare(
             'INSERT INTO assets (
@@ -578,7 +403,7 @@ final class AssetsTableBootstrapTest extends TestCase
      * @param array<string, int|string|null> $overrides
      * @param array<string, int|string|null>|null $baseRow
      */
-    private function assertInsertFails(
+    protected function assertInsertFails(
         PDO $connection,
         array $overrides,
         string $message,
@@ -608,7 +433,7 @@ final class AssetsTableBootstrapTest extends TestCase
     /**
      * @return array{status: string, chunk_count: int, completion_proof: string|null, created_at: string, updated_at: string}
      */
-    private function fetchPersistedLifecycleState(PDO $connection, string $uploadId): array
+    protected function fetchPersistedLifecycleState(PDO $connection, string $uploadId): array
     {
         $statement = $connection->prepare(
             'SELECT status, chunk_count, completion_proof, created_at, updated_at
@@ -650,10 +475,8 @@ final class AssetsTableBootstrapTest extends TestCase
         ];
     }
 
-    /**
-     * @return array<string, int|string|null>
-     */
-    private function validPendingRow(): array
+    /** @return array<string, int|string|null> */
+    protected function validPendingRow(): array
     {
         return [
             'id' => '11111111-1111-4111-8111-111111111111',
@@ -669,10 +492,8 @@ final class AssetsTableBootstrapTest extends TestCase
         ];
     }
 
-    /**
-     * @return array<string, int|string|null>
-     */
-    private function validFailedRow(): array
+    /** @return array<string, int|string|null> */
+    protected function validFailedRow(): array
     {
         return array_replace(
             $this->validPendingRow(),
@@ -686,10 +507,8 @@ final class AssetsTableBootstrapTest extends TestCase
         );
     }
 
-    /**
-     * @return array<string, int|string|null>
-     */
-    private function validUploadedRow(): array
+    /** @return array<string, int|string|null> */
+    protected function validUploadedRow(): array
     {
         return array_replace(
             $this->validPendingRow(),
@@ -704,7 +523,7 @@ final class AssetsTableBootstrapTest extends TestCase
         );
     }
 
-    private function quoteIdentifier(string $identifier): string
+    protected function quoteIdentifier(string $identifier): string
     {
         return '`' . str_replace('`', '``', $identifier) . '`';
     }

--- a/tests/Integration/Infrastructure/Persistence/BaseAssetsTableTestCase.php
+++ b/tests/Integration/Infrastructure/Persistence/BaseAssetsTableTestCase.php
@@ -8,7 +8,7 @@ use PDO;
 use PDOException;
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseAssetsTableTest extends TestCase
+abstract class BaseAssetsTableTestCase extends TestCase
 {
     protected const ACCOUNT_ID_INDEX_NAME = 'idx_assets_account_id';
     protected const TABLE_NAME = 'assets';
@@ -326,8 +326,8 @@ abstract class BaseAssetsTableTest extends TestCase
              WHERE TABLE_SCHEMA = DATABASE()
                AND TABLE_NAME = :tableName
                AND NON_UNIQUE = 0
-                             AND INDEX_NAME <> :primaryIndex
-                         ORDER BY INDEX_NAME, SEQ_IN_INDEX',
+               AND INDEX_NAME <> :primaryIndex
+               ORDER BY INDEX_NAME, SEQ_IN_INDEX',
         );
         $statement->execute([
             'tableName' => self::TABLE_NAME,

--- a/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
@@ -33,7 +33,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     private ?array $selectedConnection = null;
 
     #[Test]
-    public function itSavesAndReadsAPendingAsset(): void
+    public function itReturnsAssetWhenSavingAndReadingAPendingAsset(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -59,7 +59,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itSavesAndReadsAnUploadedAsset(): void
+    public function itReturnsAssetWhenSavingAndReadingAnUploadedAsset(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -86,7 +86,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itUpdatesAnExistingRowAfterAnAssetStateChange(): void
+    public function itReturnsUpdatedRowWhenAssetStateChanges(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -112,7 +112,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itAcceptsALegitimateStateChangeWhenUpdatedAtRemainsEqual(): void
+    public function itReturnsAcceptedStateWhenUpdatedAtRemainsEqual(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -140,7 +140,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itKeepsASingleRowWhenSavingTheSameUnchangedAssetTwice(): void
+    public function itReturnsSingleRowWhenSavingUnchangedAssetTwice(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {

--- a/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
@@ -165,7 +165,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itRejectsALaterSaveWhenTheSameAssetIdentityChangesAnImmutableField(): void
+    public function itThrowsStaleAssetWriteExceptionWhenSameAssetIdentityChangesImmutableField(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -209,7 +209,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itRejectsAStaleSaveAndPreservesTheNewerPersistedState(): void
+    public function itThrowsStaleAssetWriteExceptionWhenSavingStaleAssetAndPreservesNewerPersistedState(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -254,7 +254,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itRejectsAStaleSaveWhenTheCompareAndSwapUpdateLosesARace(): void
+    public function itThrowsStaleAssetWriteExceptionWhenCompareAndSwapUpdateLosesRace(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -319,6 +319,52 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function itReturnsSuccessfullyWhenTheCompareAndSwapUpdateLosesARaceButTheRowAlreadyMatchesTheDesiredState(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $persistedAsset = $this->pendingAsset(
+                assetId: '30303030-3030-4030-8030-303030303030',
+                uploadId: '40404040-4040-4040-8040-404040404040',
+                accountId: 'account-compare-and-swap-idempotent-race',
+                fileName: 'race-idempotent.png',
+                createdAt: '2026-04-01 13:25:00.000000',
+            );
+            $uploadedAsset = $this->uploadedAsset(
+                assetId: (string) $persistedAsset->getId(),
+                uploadId: (string) $persistedAsset->getUploadId(),
+                accountId: (string) $persistedAsset->getAccountId(),
+                fileName: $persistedAsset->getFileName(),
+                completionProof: 'etag-idempotent-race-winner',
+                persistedState: $this->persistedState(
+                    '2026-04-01 13:25:00.000000',
+                    1,
+                    '2026-04-01 13:30:00.000000',
+                ),
+            );
+
+            $repository->save($persistedAsset);
+
+            $raceConnection = $this->createCompareAndSwapRaceConnection(
+                $this->currentDatabaseName($connection),
+                function () use ($connection, $uploadedAsset): void {
+                    $this->forceUploadedAssetState($connection, $uploadedAsset);
+                },
+            );
+            $raceRepository = new MySQLAssetRepository($raceConnection);
+
+            $raceRepository->save($uploadedAsset);
+            $persistedAfterRace = $repository->findById($persistedAsset->getId());
+
+            // Assert
+            self::assertNotNull($persistedAfterRace);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($uploadedAsset, $persistedAfterRace);
+        });
+    }
+
+    #[Test]
     public function itReturnsNullWhenAnAssetIsMissing(): void
     {
         // Arrange & Act
@@ -334,7 +380,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itSearchesByFileNameWithinAnAccountUsingDeterministicOrdering(): void
+    public function itReturnsMatchingAssetsWhenSearchingByFileNameWithinAccountUsingDeterministicOrdering(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -393,7 +439,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itReturnsAnEmptyListForAnEmptyTrimmedSearchQueryWithoutQueryingTheTable(): void
+    public function itReturnsAnEmptyListWhenSearchQueryIsEmptyAfterTrimming(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -406,7 +452,7 @@ final class MySQLAssetRepositoryTest extends TestCase
     }
 
     #[Test]
-    public function itSurfacesADatabaseExceptionWhenADifferentAssetReusesAnExistingUploadId(): void
+    public function itThrowsPdoExceptionWhenDifferentAssetReusesExistingUploadId(): void
     {
         // Arrange & Act
         $this->withTemporaryDatabase(function (PDO $connection): void {
@@ -668,6 +714,25 @@ final class MySQLAssetRepositoryTest extends TestCase
         ]);
     }
 
+    private function forceUploadedAssetState(PDO $connection, Asset $asset): void
+    {
+        $statement = $connection->prepare(
+            'UPDATE assets
+             SET status = :status,
+                 chunk_count = :chunk_count,
+                 completion_proof = :completion_proof,
+                 updated_at = :updated_at
+             WHERE id = :id',
+        );
+        $statement->execute([
+            'id' => (string) $asset->getId(),
+            'status' => $asset->getStatus()->value,
+            'chunk_count' => $asset->getChunkCount(),
+            'completion_proof' => $asset->getCompletionProof()?->value,
+            'updated_at' => $asset->getUpdatedAt()->format(self::DATETIME_FORMAT),
+        ]);
+    }
+
     private function countAssets(PDO $connection): int
     {
         $statement = $connection->prepare('SELECT COUNT(*) AS asset_count FROM assets');
@@ -735,9 +800,9 @@ final class MySQLAssetRepositoryTest extends TestCase
     private function persistedState(string $createdAt, int $chunkCount = 1, ?string $updatedAt = null): array
     {
         return [
-            'createdAt' => new DateTimeImmutable($createdAt),
+            'createdAt' => new DateTimeImmutable($createdAt, new \DateTimeZone('UTC')),
             'chunkCount' => $chunkCount,
-            'updatedAt' => new DateTimeImmutable($updatedAt ?? $createdAt),
+            'updatedAt' => new DateTimeImmutable($updatedAt ?? $createdAt, new \DateTimeZone('UTC')),
         ];
     }
 
@@ -755,12 +820,12 @@ final class MySQLAssetRepositoryTest extends TestCase
             $actual->getCompletionProof()?->value,
         );
         self::assertSame(
-            $expected->getCreatedAt()->format(self::DATETIME_FORMAT),
-            $actual->getCreatedAt()->format(self::DATETIME_FORMAT),
+            $expected->getCreatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
+            $actual->getCreatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
         );
         self::assertSame(
-            $expected->getUpdatedAt()->format(self::DATETIME_FORMAT),
-            $actual->getUpdatedAt()->format(self::DATETIME_FORMAT),
+            $expected->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
+            $actual->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format(self::DATETIME_FORMAT),
         );
     }
 

--- a/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
@@ -1,0 +1,784 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Persistence;
+
+use App\Domain\Asset\Asset;
+use App\Domain\Asset\AssetStatus;
+use App\Domain\Asset\Exception\StaleAssetWriteException;
+use App\Domain\Asset\ValueObject\AccountId;
+use App\Domain\Asset\ValueObject\AssetId;
+use App\Domain\Asset\ValueObject\UploadCompletionProofValue;
+use App\Domain\Asset\ValueObject\UploadId;
+use App\Infrastructure\Persistence\MySQLAssetRepository;
+use App\Tests\Integration\Support\CompareAndSwapRacePdo;
+use Closure;
+use DateTimeImmutable;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MySQLAssetRepositoryTest extends TestCase
+{
+    private const DATETIME_FORMAT = 'Y-m-d H:i:s.u';
+    private const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
+    private const MIGRATION_FILE = __DIR__ . '/../../../../migrations/20260401120000_create_assets_table.sql';
+    private const MIME_TYPE = 'image/png';
+
+    /**
+     * @var array{host: string, port: int, user: string, password: string}|null
+     */
+    private ?array $selectedConnection = null;
+
+    #[Test]
+    public function itSavesAndReadsAPendingAsset(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $asset = $this->pendingAsset(
+                assetId: '11111111-1111-4111-8111-111111111111',
+                uploadId: '22222222-2222-4222-8222-222222222222',
+                accountId: 'account-pending',
+                fileName: 'Pending-image.PNG',
+                createdAt: '2026-04-01 10:00:00.000000',
+            );
+
+            $repository->save($asset);
+            $foundById = $repository->findById($asset->getId());
+            $foundByUploadId = $repository->findByUploadId($asset->getUploadId());
+
+            // Assert
+            self::assertNotNull($foundById);
+            self::assertNotNull($foundByUploadId);
+            $this->assertAssetMatches($asset, $foundById);
+            $this->assertAssetMatches($asset, $foundByUploadId);
+        });
+    }
+
+    #[Test]
+    public function itSavesAndReadsAnUploadedAsset(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $asset = $this->uploadedAsset(
+                assetId: '33333333-3333-4333-8333-333333333333',
+                uploadId: '44444444-4444-4444-8444-444444444444',
+                accountId: 'account-uploaded',
+                fileName: 'uploaded-image.png',
+                completionProof: 'etag-uploaded-asset',
+                persistedState: $this->persistedState('2026-04-01 09:00:00.000000', 3, '2026-04-01 09:05:00.000000'),
+            );
+
+            $repository->save($asset);
+            $foundById = $repository->findById($asset->getId());
+            $foundByUploadId = $repository->findByUploadId($asset->getUploadId());
+
+            // Assert
+            self::assertNotNull($foundById);
+            self::assertNotNull($foundByUploadId);
+            $this->assertAssetMatches($asset, $foundById);
+            $this->assertAssetMatches($asset, $foundByUploadId);
+        });
+    }
+
+    #[Test]
+    public function itUpdatesAnExistingRowAfterAnAssetStateChange(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $asset = $this->pendingAsset(
+                assetId: '55555555-5555-4555-8555-555555555555',
+                uploadId: '66666666-6666-4666-8666-666666666666',
+                accountId: 'account-state-change',
+                fileName: 'asset-before-upload.png',
+                createdAt: '2020-01-01 12:00:00.000000',
+            );
+
+            $repository->save($asset);
+            $asset->markUploaded(new UploadCompletionProofValue('etag-after-upload'));
+            $repository->save($asset);
+            $persistedAsset = $repository->findById($asset->getId());
+
+            // Assert
+            self::assertNotNull($persistedAsset);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($asset, $persistedAsset);
+        });
+    }
+
+    #[Test]
+    public function itAcceptsALegitimateStateChangeWhenUpdatedAtRemainsEqual(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $asset = $this->pendingAsset(
+                assetId: '56565656-5656-4565-8565-565656565656',
+                uploadId: '67676767-6767-4676-8676-676767676767',
+                accountId: 'account-equal-updated-at',
+                fileName: 'equal-updated-at.png',
+                createdAt: '9999-01-01 00:00:00.000000',
+            );
+            $originalUpdatedAt = $asset->getUpdatedAt()->format(self::DATETIME_FORMAT);
+
+            $repository->save($asset);
+            $asset->markUploaded(new UploadCompletionProofValue('etag-equal-updated-at'));
+            $repository->save($asset);
+            $persistedAsset = $repository->findById($asset->getId());
+
+            // Assert
+            self::assertSame($originalUpdatedAt, $asset->getUpdatedAt()->format(self::DATETIME_FORMAT));
+            self::assertNotNull($persistedAsset);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($asset, $persistedAsset);
+        });
+    }
+
+    #[Test]
+    public function itKeepsASingleRowWhenSavingTheSameUnchangedAssetTwice(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $asset = $this->pendingAsset(
+                assetId: '77777777-0000-4777-8777-777777777777',
+                uploadId: '88888888-0000-4888-8888-888888888888',
+                accountId: 'account-idempotent-save',
+                fileName: 'same-asset.png',
+                createdAt: '2026-04-01 12:30:00.000000',
+            );
+
+            $repository->save($asset);
+            $repository->save($asset);
+            $persistedAsset = $repository->findById($asset->getId());
+
+            // Assert
+            self::assertNotNull($persistedAsset);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($asset, $persistedAsset);
+        });
+    }
+
+    #[Test]
+    public function itRejectsALaterSaveWhenTheSameAssetIdentityChangesAnImmutableField(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $persistedAsset = $this->pendingAsset(
+                assetId: '12121212-1212-4212-8212-121212121212',
+                uploadId: '34343434-3434-4434-8434-343434343434',
+                accountId: 'account-immutable-field-guard',
+                fileName: 'original-name.png',
+                createdAt: '2026-04-01 12:45:00.000000',
+            );
+            $assetWithChangedImmutableField = $this->uploadedAsset(
+                assetId: (string) $persistedAsset->getId(),
+                uploadId: (string) $persistedAsset->getUploadId(),
+                accountId: (string) $persistedAsset->getAccountId(),
+                fileName: 'renamed-after-upload.png',
+                completionProof: 'etag-immutable-field-change',
+                persistedState: $this->persistedState(
+                    '2026-04-01 12:45:00.000000',
+                    1,
+                    '2026-04-01 12:50:00.000000',
+                ),
+            );
+
+            $repository->save($persistedAsset);
+
+            try {
+                $repository->save($assetWithChangedImmutableField);
+                self::fail('Expected immutable field change to throw a StaleAssetWriteException.');
+            } catch (StaleAssetWriteException $exception) {
+                self::assertSame('Cannot save stale asset state.', $exception->getMessage());
+            }
+
+            $storedAsset = $repository->findById($persistedAsset->getId());
+
+            // Assert
+            self::assertNotNull($storedAsset);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($persistedAsset, $storedAsset);
+        });
+    }
+
+    #[Test]
+    public function itRejectsAStaleSaveAndPreservesTheNewerPersistedState(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $staleAsset = $this->pendingAsset(
+                assetId: '99999999-0000-4999-8999-999999999999',
+                uploadId: 'aaaaaaaa-0000-4aaa-8aaa-aaaaaaaaaaaa',
+                accountId: 'account-stale-save',
+                fileName: 'stale-copy.png',
+                createdAt: '2026-04-01 13:00:00.000000',
+            );
+            $newerAsset = $this->uploadedAsset(
+                assetId: (string) $staleAsset->getId(),
+                uploadId: (string) $staleAsset->getUploadId(),
+                accountId: (string) $staleAsset->getAccountId(),
+                fileName: $staleAsset->getFileName(),
+                completionProof: 'etag-newer-state',
+                persistedState: $this->persistedState(
+                    '2026-04-01 13:00:00.000000',
+                    1,
+                    '2026-04-01 13:05:00.000000',
+                ),
+            );
+
+            $repository->save($staleAsset);
+            $repository->save($newerAsset);
+
+            try {
+                $repository->save($staleAsset);
+                self::fail('Expected stale asset save to throw a StaleAssetWriteException.');
+            } catch (StaleAssetWriteException $exception) {
+                self::assertSame('Cannot save stale asset state.', $exception->getMessage());
+            }
+
+            $persistedAsset = $repository->findById($staleAsset->getId());
+
+            // Assert
+            self::assertNotNull($persistedAsset);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($newerAsset, $persistedAsset);
+        });
+    }
+
+    #[Test]
+    public function itRejectsAStaleSaveWhenTheCompareAndSwapUpdateLosesARace(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $persistedAsset = $this->pendingAsset(
+                assetId: '10101010-1010-4010-8010-101010101010',
+                uploadId: '20202020-2020-4020-8020-202020202020',
+                accountId: 'account-compare-and-swap-race',
+                fileName: 'race-window.png',
+                createdAt: '2026-04-01 13:15:00.000000',
+            );
+            $uploadedAsset = $this->uploadedAsset(
+                assetId: (string) $persistedAsset->getId(),
+                uploadId: (string) $persistedAsset->getUploadId(),
+                accountId: (string) $persistedAsset->getAccountId(),
+                fileName: $persistedAsset->getFileName(),
+                completionProof: 'etag-race-winner',
+                persistedState: $this->persistedState(
+                    '2026-04-01 13:15:00.000000',
+                    1,
+                    '2026-04-01 13:20:00.000000',
+                ),
+            );
+            $concurrentPersistedAsset = Asset::reconstitute(
+                new AssetId((string) $persistedAsset->getId()),
+                new UploadId((string) $persistedAsset->getUploadId()),
+                new AccountId((string) $persistedAsset->getAccountId()),
+                $persistedAsset->getFileName(),
+                $persistedAsset->getMimeType(),
+                AssetStatus::FAILED,
+                $this->persistedState(
+                    '2026-04-01 13:15:00.000000',
+                    1,
+                    '2026-04-01 13:18:00.000000',
+                ),
+            );
+
+            $repository->save($persistedAsset);
+
+            $raceConnection = $this->createCompareAndSwapRaceConnection(
+                $this->currentDatabaseName($connection),
+                function () use ($connection, $persistedAsset, $concurrentPersistedAsset): void {
+                    $this->forceFailedAssetState($connection, $persistedAsset, $concurrentPersistedAsset->getUpdatedAt());
+                },
+            );
+            $raceRepository = new MySQLAssetRepository($raceConnection);
+
+            try {
+                $raceRepository->save($uploadedAsset);
+                self::fail('Expected compare-and-swap update to throw a StaleAssetWriteException.');
+            } catch (StaleAssetWriteException $exception) {
+                self::assertSame('Cannot save stale asset state.', $exception->getMessage());
+            }
+
+            $persistedAfterRace = $repository->findById($persistedAsset->getId());
+
+            // Assert
+            self::assertNotNull($persistedAfterRace);
+            self::assertSame(1, $this->countAssets($connection));
+            $this->assertAssetMatches($concurrentPersistedAsset, $persistedAfterRace);
+        });
+    }
+
+    #[Test]
+    public function itReturnsNullWhenAnAssetIsMissing(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $missingAsset = $repository->findById(new AssetId('77777777-7777-4777-8777-777777777777'));
+            $missingUpload = $repository->findByUploadId(new UploadId('88888888-8888-4888-8888-888888888888'));
+
+            // Assert
+            self::assertNull($missingAsset);
+            self::assertNull($missingUpload);
+        });
+    }
+
+    #[Test]
+    public function itSearchesByFileNameWithinAnAccountUsingDeterministicOrdering(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $accountId = new AccountId('account-search');
+            $expectedFirst = $this->uploadedAsset(
+                assetId: '99999999-9999-4999-8999-999999999999',
+                uploadId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                accountId: (string) $accountId,
+                fileName: 'Quarterly Report.pdf',
+                completionProof: 'etag-quarterly-report',
+                persistedState: $this->persistedState('2026-04-01 14:00:00.000000', 1, '2026-04-01 14:05:00.000000'),
+            );
+            $expectedSecond = $this->pendingAsset(
+                assetId: '11111111-aaaa-4111-8111-111111111111',
+                uploadId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+                accountId: (string) $accountId,
+                fileName: 'report-draft.png',
+                createdAt: '2026-04-01 13:00:00.000000',
+            );
+            $expectedThird = $this->pendingAsset(
+                assetId: '22222222-bbbb-4222-8222-222222222222',
+                uploadId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+                accountId: (string) $accountId,
+                fileName: 'REPORT-appendix.png',
+                createdAt: '2026-04-01 13:00:00.000000',
+            );
+            $sameAccountNonMatch = $this->pendingAsset(
+                assetId: '33333333-cccc-4333-8333-333333333333',
+                uploadId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+                accountId: (string) $accountId,
+                fileName: 'invoice.png',
+                createdAt: '2026-04-01 15:00:00.000000',
+            );
+            $otherAccountMatch = $this->pendingAsset(
+                assetId: '44444444-dddd-4444-8444-444444444444',
+                uploadId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+                accountId: 'account-other',
+                fileName: 'external-report.png',
+                createdAt: '2026-04-01 16:00:00.000000',
+            );
+
+            $repository->save($expectedThird);
+            $repository->save($otherAccountMatch);
+            $repository->save($expectedFirst);
+            $repository->save($sameAccountNonMatch);
+            $repository->save($expectedSecond);
+            $results = $repository->searchByFileName($accountId, '  repORT  ');
+
+            // Assert
+            self::assertCount(3, $results);
+            $this->assertAssetMatches($expectedFirst, $results[0]);
+            $this->assertAssetMatches($expectedSecond, $results[1]);
+            $this->assertAssetMatches($expectedThird, $results[2]);
+        });
+    }
+
+    #[Test]
+    public function itReturnsAnEmptyListForAnEmptyTrimmedSearchQueryWithoutQueryingTheTable(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $results = $repository->searchByFileName(new AccountId('account-empty-search'), " \n\t ");
+
+            // Assert
+            self::assertSame([], $results);
+        }, false);
+    }
+
+    #[Test]
+    public function itSurfacesADatabaseExceptionWhenADifferentAssetReusesAnExistingUploadId(): void
+    {
+        // Arrange & Act
+        $this->withTemporaryDatabase(function (PDO $connection): void {
+            $repository = new MySQLAssetRepository($connection);
+            $existingAsset = $this->pendingAsset(
+                assetId: '55555555-eeee-4555-8555-555555555555',
+                uploadId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+                accountId: 'account-duplicate-upload',
+                fileName: 'existing.png',
+                createdAt: '2026-04-01 11:00:00.000000',
+            );
+            $duplicateUploadIdAsset = $this->pendingAsset(
+                assetId: '66666666-ffff-4666-8666-666666666666',
+                uploadId: (string) $existingAsset->getUploadId(),
+                accountId: 'account-duplicate-upload',
+                fileName: 'replacement.png',
+                createdAt: '2026-04-01 11:05:00.000000',
+            );
+
+            $repository->save($existingAsset);
+
+            $this->expectException(PDOException::class);
+
+            try {
+                $repository->save($duplicateUploadIdAsset);
+            } finally {
+                $persistedAsset = $repository->findByUploadId($existingAsset->getUploadId());
+
+                self::assertNotNull($persistedAsset);
+                self::assertSame(1, $this->countAssets($connection));
+                self::assertNull($repository->findById($duplicateUploadIdAsset->getId()));
+                $this->assertAssetMatches($existingAsset, $persistedAsset);
+            }
+        });
+    }
+
+    /**
+     * @param callable(PDO): void $assertions
+     */
+    private function withTemporaryDatabase(callable $assertions, bool $applyMigration = true): void
+    {
+        $serverConnection = $this->createServerConnectionOrSkip();
+        $databaseName = 'dam_repository_' . bin2hex(random_bytes(6));
+        $this->createDatabase($serverConnection, $databaseName);
+        $databaseConnection = null;
+
+        try {
+            $databaseConnection = $this->createDatabaseConnection($databaseName);
+
+            if ($applyMigration) {
+                $databaseConnection->exec($this->migrationSql());
+            }
+
+            $assertions($databaseConnection);
+        } finally {
+            $databaseConnection = null;
+            $this->dropDatabase($serverConnection, $databaseName);
+        }
+    }
+
+    private function migrationSql(): string
+    {
+        $migrationSql = file_get_contents(self::MIGRATION_FILE);
+
+        if ($migrationSql === false) {
+            self::fail('Failed to read the assets table bootstrap migration.');
+        }
+
+        return $migrationSql;
+    }
+
+    private function createServerConnectionOrSkip(): PDO
+    {
+        if (! class_exists(PDO::class)) {
+            self::markTestSkipped('PDO is not available in this PHP runtime.');
+        }
+
+        $connectionErrors = [];
+
+        foreach ($this->connectionCandidates() as $candidate) {
+            $dsn = sprintf(
+                'mysql:host=%s;port=%d;charset=utf8mb4',
+                $candidate['host'],
+                $candidate['port'],
+            );
+
+            try {
+                $connection = $this->createConnection($dsn, $candidate['user'], $candidate['password']);
+                $this->selectedConnection = $candidate;
+
+                return $connection;
+            } catch (PDOException $exception) {
+                $connectionErrors[] = sprintf(
+                    '%s:%d (%s)',
+                    $candidate['host'],
+                    $candidate['port'],
+                    $exception->getMessage(),
+                );
+            }
+        }
+
+        self::markTestSkipped(
+            'MySQL is not reachable for integration tests. Tried: ' . implode('; ', $connectionErrors),
+        );
+    }
+
+    private function createDatabaseConnection(string $databaseName): PDO
+    {
+        $selectedConnection = $this->selectedConnection;
+
+        if ($selectedConnection === null) {
+            self::fail('MySQL connection settings were not initialized.');
+        }
+
+        return $this->createConnection(
+            $this->databaseDsn($selectedConnection, $databaseName),
+            $selectedConnection['user'],
+            $selectedConnection['password'],
+        );
+    }
+
+    private function createCompareAndSwapRaceConnection(string $databaseName, Closure $beforeCompareAndSwap): PDO
+    {
+        $selectedConnection = $this->selectedConnection;
+
+        if ($selectedConnection === null) {
+            self::fail('MySQL connection settings were not initialized.');
+        }
+
+        return new CompareAndSwapRacePdo(
+            $this->databaseDsn($selectedConnection, $databaseName),
+            $selectedConnection['user'],
+            $selectedConnection['password'],
+            $beforeCompareAndSwap,
+        );
+    }
+
+    private function createConnection(string $dsn, string $user, string $password): PDO
+    {
+        return new PDO(
+            $dsn,
+            $user,
+            $password,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ],
+        );
+    }
+
+    private function createDatabase(PDO $connection, string $databaseName): void
+    {
+        $connection->exec(
+            sprintf(
+                'CREATE DATABASE %s CHARACTER SET utf8mb4 COLLATE %s',
+                $this->quoteIdentifier($databaseName),
+                self::FILE_NAME_COLLATION,
+            ),
+        );
+    }
+
+    private function dropDatabase(PDO $connection, string $databaseName): void
+    {
+        $connection->exec('DROP DATABASE IF EXISTS ' . $this->quoteIdentifier($databaseName));
+    }
+
+    /**
+     * @return list<array{host: string, port: int, user: string, password: string}>
+     */
+    private function connectionCandidates(): array
+    {
+        $user = $this->env('DB_USER', 'root');
+        $password = $this->env('DB_PASSWORD', 'root');
+        $candidates = [[
+            'host' => $this->env('DB_HOST', '127.0.0.1'),
+            'port' => $this->envInt('DB_PORT', 3306),
+            'user' => $user,
+            'password' => $password,
+        ]];
+
+        $fallbackCandidate = [
+            'host' => '127.0.0.1',
+            'port' => $this->envInt('DB_HOST_PORT', 3307),
+            'user' => $user,
+            'password' => $password,
+        ];
+
+        if (
+            $fallbackCandidate['host'] !== $candidates[0]['host']
+            || $fallbackCandidate['port'] !== $candidates[0]['port']
+        ) {
+            $candidates[] = $fallbackCandidate;
+        }
+
+        return $candidates;
+    }
+
+    private function env(string $name, string $defaultValue): string
+    {
+        $value = getenv($name);
+
+        if ($value === false) {
+            return $defaultValue;
+        }
+
+        $trimmedValue = trim($value);
+
+        return $trimmedValue === '' ? $defaultValue : $trimmedValue;
+    }
+
+    private function envInt(string $name, int $defaultValue): int
+    {
+        $value = getenv($name);
+
+        if ($value === false) {
+            return $defaultValue;
+        }
+
+        $trimmedValue = trim($value);
+
+        if ($trimmedValue === '' || ! ctype_digit($trimmedValue)) {
+            return $defaultValue;
+        }
+
+        return (int) $trimmedValue;
+    }
+
+    private function currentDatabaseName(PDO $connection): string
+    {
+        $statement = $connection->prepare('SELECT DATABASE() AS database_name');
+        $statement->execute();
+        $row = $statement->fetch();
+
+        if (! is_array($row)) {
+            self::fail('Unexpected database name query result.');
+        }
+
+        $databaseName = $row['database_name'] ?? null;
+
+        if (! is_string($databaseName) || trim($databaseName) === '') {
+            self::fail('Unexpected database name query result.');
+        }
+
+        return $databaseName;
+    }
+
+    private function forceFailedAssetState(PDO $connection, Asset $asset, DateTimeImmutable $updatedAt): void
+    {
+        $statement = $connection->prepare(
+            'UPDATE assets
+             SET status = :status,
+                 updated_at = :updated_at
+             WHERE id = :id',
+        );
+        $statement->execute([
+            'id' => (string) $asset->getId(),
+            'status' => AssetStatus::FAILED->value,
+            'updated_at' => $updatedAt->format(self::DATETIME_FORMAT),
+        ]);
+    }
+
+    private function countAssets(PDO $connection): int
+    {
+        $statement = $connection->prepare('SELECT COUNT(*) AS asset_count FROM assets');
+        $statement->execute();
+        $row = $statement->fetch();
+
+        if (! is_array($row)) {
+            self::fail('Unexpected count query result.');
+        }
+
+        $assetCount = $row['asset_count'] ?? null;
+
+        if (! is_numeric($assetCount)) {
+            self::fail('Unexpected count query result.');
+        }
+
+        return (int) $assetCount;
+    }
+
+    private function pendingAsset(
+        string $assetId,
+        string $uploadId,
+        string $accountId,
+        string $fileName,
+        string $createdAt,
+        ?string $updatedAt = null,
+        int $chunkCount = 1,
+    ): Asset {
+        return Asset::reconstitute(
+            new AssetId($assetId),
+            new UploadId($uploadId),
+            new AccountId($accountId),
+            $fileName,
+            self::MIME_TYPE,
+            AssetStatus::PENDING,
+            $this->persistedState($createdAt, $chunkCount, $updatedAt),
+        );
+    }
+
+    /**
+     * @param array{createdAt: DateTimeImmutable, chunkCount: int, updatedAt: DateTimeImmutable} $persistedState
+     */
+    private function uploadedAsset(
+        string $assetId,
+        string $uploadId,
+        string $accountId,
+        string $fileName,
+        string $completionProof,
+        array $persistedState,
+    ): Asset {
+        return Asset::reconstituteUploaded(
+            new AssetId($assetId),
+            new UploadId($uploadId),
+            new AccountId($accountId),
+            $fileName,
+            self::MIME_TYPE,
+            new UploadCompletionProofValue($completionProof),
+            $persistedState,
+        );
+    }
+
+    /**
+     * @return array{createdAt: DateTimeImmutable, chunkCount: int, updatedAt: DateTimeImmutable}
+     */
+    private function persistedState(string $createdAt, int $chunkCount = 1, ?string $updatedAt = null): array
+    {
+        return [
+            'createdAt' => new DateTimeImmutable($createdAt),
+            'chunkCount' => $chunkCount,
+            'updatedAt' => new DateTimeImmutable($updatedAt ?? $createdAt),
+        ];
+    }
+
+    private function assertAssetMatches(Asset $expected, Asset $actual): void
+    {
+        self::assertSame((string) $expected->getId(), (string) $actual->getId());
+        self::assertSame((string) $expected->getUploadId(), (string) $actual->getUploadId());
+        self::assertSame((string) $expected->getAccountId(), (string) $actual->getAccountId());
+        self::assertSame($expected->getFileName(), $actual->getFileName());
+        self::assertSame($expected->getMimeType(), $actual->getMimeType());
+        self::assertSame($expected->getStatus(), $actual->getStatus());
+        self::assertSame($expected->getChunkCount(), $actual->getChunkCount());
+        self::assertSame(
+            $expected->getCompletionProof()?->value,
+            $actual->getCompletionProof()?->value,
+        );
+        self::assertSame(
+            $expected->getCreatedAt()->format(self::DATETIME_FORMAT),
+            $actual->getCreatedAt()->format(self::DATETIME_FORMAT),
+        );
+        self::assertSame(
+            $expected->getUpdatedAt()->format(self::DATETIME_FORMAT),
+            $actual->getUpdatedAt()->format(self::DATETIME_FORMAT),
+        );
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
+    /**
+     * @param array{host: string, port: int, user: string, password: string} $connection
+     */
+    private function databaseDsn(array $connection, string $databaseName): string
+    {
+        return sprintf(
+            'mysql:host=%s;port=%d;dbname=%s;charset=utf8mb4',
+            $connection['host'],
+            $connection['port'],
+            $databaseName,
+        );
+    }
+}

--- a/tests/Integration/Support/CompareAndSwapRacePdo.php
+++ b/tests/Integration/Support/CompareAndSwapRacePdo.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Support;
+
+use Closure;
+use PDO;
+use PDOStatement;
+
+final class CompareAndSwapRacePdo extends PDO
+{
+    private const UPDATE_ASSETS_PREFIX = 'UPDATE assets';
+
+    public function __construct(
+        string $dsn,
+        string $user,
+        string $password,
+        private readonly Closure $beforeCompareAndSwap,
+    ) {
+        parent::__construct(
+            $dsn,
+            $user,
+            $password,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ],
+        );
+    }
+
+    /**
+     * @param array<int, mixed> $options
+     */
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        if (str_starts_with(ltrim($query), self::UPDATE_ASSETS_PREFIX)) {
+            $options[PDO::ATTR_STATEMENT_CLASS] = [
+                CompareAndSwapRaceStatement::class,
+                [$this->beforeCompareAndSwap],
+            ];
+        }
+
+        return parent::prepare($query, $options);
+    }
+}

--- a/tests/Integration/Support/CompareAndSwapRaceStatement.php
+++ b/tests/Integration/Support/CompareAndSwapRaceStatement.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Support;
+
+use Closure;
+use PDOStatement;
+
+final class CompareAndSwapRaceStatement extends PDOStatement
+{
+    private bool $hasTriggeredCompareAndSwapRace = false;
+
+    protected function __construct(
+        private readonly Closure $beforeCompareAndSwap,
+    ) {
+    }
+
+    /**
+     * @param array<string|int, mixed>|null $params
+     */
+    public function execute(?array $params = null): bool
+    {
+        if (! $this->hasTriggeredCompareAndSwapRace) {
+            ($this->beforeCompareAndSwap)();
+            $this->hasTriggeredCompareAndSwapRace = true;
+        }
+
+        return parent::execute($params);
+    }
+}

--- a/tests/Unit/Domain/Asset/AssetTest.php
+++ b/tests/Unit/Domain/Asset/AssetTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 final class AssetTest extends TestCase
 {
+    private const DEFAULT_CHUNK_COUNT = 1;
+    private const CHUNK_COUNT = 4;
     private const ASSET_ID = '123e4567-e89b-42d3-a456-426614174099';
     private const OTHER_ASSET_ID = '123e4567-e89b-42d3-a456-426614174098';
     private const FIRST_UPLOAD_ID = '123e4567-e89b-42d3-a456-426614174000';
@@ -26,6 +28,10 @@ final class AssetTest extends TestCase
     private const FILE_NAME = 'image.png';
     private const MIME_TYPE = 'image/png';
     private const COMPLETION_PROOF_VALUE = 'etag-value';
+    private const CREATED_AT = '2020-01-20T12:34:56+00:00';
+    private const UPDATED_AT = '2020-01-21T12:34:56+00:00';
+    private const INVALID_CHUNK_COUNT_MESSAGE = 'Chunk count must be at least 1';
+    private const INVALID_UPDATED_AT_MESSAGE = 'Updated at must not be earlier than created at';
     private const UUID_V4_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
 
     #[Test]
@@ -50,8 +56,10 @@ final class AssetTest extends TestCase
         self::assertSame(self::FILE_NAME, $asset->getFileName());
         self::assertSame(self::MIME_TYPE, $asset->getMimeType());
         self::assertSame(AssetStatus::PENDING, $asset->getStatus());
+        self::assertSame(self::DEFAULT_CHUNK_COUNT, $asset->getChunkCount());
         self::assertGreaterThanOrEqual($beforeCreation->getTimestamp(), $asset->getCreatedAt()->getTimestamp());
         self::assertLessThanOrEqual($afterCreation->getTimestamp(), $asset->getCreatedAt()->getTimestamp());
+        self::assertSame($asset->getCreatedAt(), $asset->getUpdatedAt());
     }
 
     #[Test]
@@ -75,7 +83,8 @@ final class AssetTest extends TestCase
         $assetId = new AssetId(self::ASSET_ID);
         $uploadId = new UploadId(self::FIRST_UPLOAD_ID);
         $accountId = new AccountId(self::ACCOUNT_ID);
-        $createdAt = new DateTimeImmutable('2026-01-20T12:34:56+00:00');
+        $createdAt = new DateTimeImmutable(self::CREATED_AT);
+        $updatedAt = new DateTimeImmutable(self::UPDATED_AT);
 
         // Act
         $asset = Asset::reconstitute(
@@ -85,7 +94,7 @@ final class AssetTest extends TestCase
             '  ' . self::FILE_NAME . '  ',
             '  ' . self::MIME_TYPE . '  ',
             AssetStatus::FAILED,
-            $createdAt,
+            $this->persistedState($createdAt, self::CHUNK_COUNT, $updatedAt),
         );
 
         // Assert
@@ -95,7 +104,9 @@ final class AssetTest extends TestCase
         self::assertSame(self::FILE_NAME, $asset->getFileName());
         self::assertSame(self::MIME_TYPE, $asset->getMimeType());
         self::assertSame(AssetStatus::FAILED, $asset->getStatus());
+        self::assertSame(self::CHUNK_COUNT, $asset->getChunkCount());
         self::assertSame($createdAt, $asset->getCreatedAt());
+        self::assertSame($updatedAt, $asset->getUpdatedAt());
     }
 
     #[Test]
@@ -105,7 +116,8 @@ final class AssetTest extends TestCase
         $assetId = new AssetId(self::ASSET_ID);
         $uploadId = new UploadId(self::FIRST_UPLOAD_ID);
         $accountId = new AccountId(self::ACCOUNT_ID);
-        $createdAt = new DateTimeImmutable('2026-01-20T12:34:56+00:00');
+        $createdAt = new DateTimeImmutable(self::CREATED_AT);
+        $updatedAt = new DateTimeImmutable(self::UPDATED_AT);
 
         // Act
         $asset = Asset::reconstituteUploaded(
@@ -114,8 +126,8 @@ final class AssetTest extends TestCase
             $accountId,
             '  ' . self::FILE_NAME . '  ',
             '  ' . self::MIME_TYPE . '  ',
-            $createdAt,
             $this->createCompletionProofValue(),
+            $this->persistedState($createdAt, self::CHUNK_COUNT, $updatedAt),
         );
 
         // Assert
@@ -125,8 +137,175 @@ final class AssetTest extends TestCase
         self::assertSame(self::FILE_NAME, $asset->getFileName());
         self::assertSame(self::MIME_TYPE, $asset->getMimeType());
         self::assertSame(AssetStatus::UPLOADED, $asset->getStatus());
+        self::assertSame(self::CHUNK_COUNT, $asset->getChunkCount());
         self::assertSame($createdAt, $asset->getCreatedAt());
+        self::assertSame($updatedAt, $asset->getUpdatedAt());
         self::assertEquals($this->createCompletionProofValue(), $asset->getCompletionProof());
+    }
+
+    #[Test]
+    public function itReturnsAssetWhenReconstitutedWithMinimumValidChunkCount(): void
+    {
+        // Arrange
+        $createdAt = new DateTimeImmutable(self::CREATED_AT);
+        $updatedAt = new DateTimeImmutable(self::UPDATED_AT);
+
+        // Act
+        $asset = Asset::reconstitute(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            AssetStatus::PENDING,
+            $this->persistedState($createdAt, self::DEFAULT_CHUNK_COUNT, $updatedAt),
+        );
+
+        // Assert
+        self::assertSame(self::DEFAULT_CHUNK_COUNT, $asset->getChunkCount());
+        self::assertSame($updatedAt, $asset->getUpdatedAt());
+    }
+
+    #[Test]
+    public function itDefaultsChunkCountAndUpdatedAtWhenReconstitutingAssetWithoutOptionalPersistedStateFields(): void
+    {
+        // Arrange
+        $createdAt = new DateTimeImmutable(self::CREATED_AT);
+
+        // Act
+        $asset = Asset::reconstitute(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            AssetStatus::PENDING,
+            [
+                'createdAt' => $createdAt,
+            ],
+        );
+
+        // Assert
+        self::assertSame(self::DEFAULT_CHUNK_COUNT, $asset->getChunkCount());
+        self::assertSame($createdAt, $asset->getUpdatedAt());
+    }
+
+    #[Test]
+    public function itDefaultsChunkCountAndUpdatedAtWhenReconstitutingUploadedAssetWithoutOptionalPersistedStateFields(): void
+    {
+        // Arrange
+        $createdAt = new DateTimeImmutable(self::CREATED_AT);
+
+        // Act
+        $asset = Asset::reconstituteUploaded(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            $this->createCompletionProofValue(),
+            [
+                'createdAt' => $createdAt,
+            ],
+        );
+
+        // Assert
+        self::assertSame(self::DEFAULT_CHUNK_COUNT, $asset->getChunkCount());
+        self::assertSame($createdAt, $asset->getUpdatedAt());
+    }
+
+    #[Test]
+    #[DataProvider('invalidChunkCountProvider')]
+    public function itThrowsAssetDomainExceptionWhenReconstitutingAssetWithInvalidChunkCount(int $chunkCount): void
+    {
+        // Arrange
+        $this->expectException(AssetDomainException::class);
+        $this->expectExceptionMessage(self::INVALID_CHUNK_COUNT_MESSAGE);
+
+        // Act
+        Asset::reconstitute(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            AssetStatus::PENDING,
+            [
+                'createdAt' => new DateTimeImmutable(self::CREATED_AT),
+                'chunkCount' => $chunkCount,
+                'updatedAt' => new DateTimeImmutable(self::UPDATED_AT),
+            ],
+        );
+    }
+
+    #[Test]
+    #[DataProvider('invalidChunkCountProvider')]
+    public function itThrowsAssetDomainExceptionWhenReconstitutingUploadedAssetWithInvalidChunkCount(int $chunkCount): void
+    {
+        // Arrange
+        $this->expectException(AssetDomainException::class);
+        $this->expectExceptionMessage(self::INVALID_CHUNK_COUNT_MESSAGE);
+
+        // Act
+        Asset::reconstituteUploaded(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            $this->createCompletionProofValue(),
+            [
+                'createdAt' => new DateTimeImmutable(self::CREATED_AT),
+                'chunkCount' => $chunkCount,
+                'updatedAt' => new DateTimeImmutable(self::UPDATED_AT),
+            ],
+        );
+    }
+
+    #[Test]
+    public function itThrowsAssetDomainExceptionWhenReconstitutingAssetWithUpdatedAtEarlierThanCreatedAt(): void
+    {
+        // Arrange
+        $this->expectException(AssetDomainException::class);
+        $this->expectExceptionMessage(self::INVALID_UPDATED_AT_MESSAGE);
+
+        // Act
+        Asset::reconstitute(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            AssetStatus::FAILED,
+            [
+                'createdAt' => new DateTimeImmutable(self::UPDATED_AT),
+                'chunkCount' => self::CHUNK_COUNT,
+                'updatedAt' => new DateTimeImmutable(self::CREATED_AT),
+            ],
+        );
+    }
+
+    #[Test]
+    public function itThrowsAssetDomainExceptionWhenReconstitutingUploadedAssetWithUpdatedAtEarlierThanCreatedAt(): void
+    {
+        // Arrange
+        $this->expectException(AssetDomainException::class);
+        $this->expectExceptionMessage(self::INVALID_UPDATED_AT_MESSAGE);
+
+        // Act
+        Asset::reconstituteUploaded(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            $this->createCompletionProofValue(),
+            [
+                'createdAt' => new DateTimeImmutable(self::UPDATED_AT),
+                'chunkCount' => self::CHUNK_COUNT,
+                'updatedAt' => new DateTimeImmutable(self::CREATED_AT),
+            ],
+        );
     }
 
     #[Test]
@@ -144,7 +323,7 @@ final class AssetTest extends TestCase
             self::FILE_NAME,
             self::MIME_TYPE,
             AssetStatus::UPLOADED,
-            new DateTimeImmutable('2026-01-20T12:34:56+00:00'),
+            $this->persistedState(new DateTimeImmutable('2026-01-20T12:34:56+00:00')),
         );
     }
 
@@ -164,7 +343,7 @@ final class AssetTest extends TestCase
             $fileName,
             $mimeType,
             AssetStatus::PENDING,
-            new DateTimeImmutable('2026-01-20T12:34:56+00:00'),
+            $this->persistedState(new DateTimeImmutable('2026-01-20T12:34:56+00:00')),
         );
     }
 
@@ -189,7 +368,8 @@ final class AssetTest extends TestCase
     public function itReturnsAssetWithUploadedStatusWhenMarkedUploaded(): void
     {
         // Arrange
-        $asset = $this->createPendingAsset();
+        $asset = $this->reconstituteAsset();
+        $originalUpdatedAt = $asset->getUpdatedAt();
 
         // Act
         $asset->markUploaded($this->createCompletionProofValue());
@@ -197,58 +377,116 @@ final class AssetTest extends TestCase
         // Assert
         self::assertSame(AssetStatus::UPLOADED, $asset->getStatus());
         self::assertEquals($this->createCompletionProofValue(), $asset->getCompletionProof());
+        self::assertGreaterThan($originalUpdatedAt->getTimestamp(), $asset->getUpdatedAt()->getTimestamp());
+    }
+
+    #[Test]
+    public function itDoesNotMoveUpdatedAtBackwardWhenMarkingUploadedWithFuturePersistedUpdatedAt(): void
+    {
+        // Arrange
+        $futureUpdatedAt = new DateTimeImmutable('2099-01-21T12:34:56+00:00');
+        $asset = $this->reconstituteAsset(updatedAt: $futureUpdatedAt);
+
+        // Act
+        $asset->markUploaded($this->createCompletionProofValue());
+
+        // Assert
+        self::assertSame(AssetStatus::UPLOADED, $asset->getStatus());
+        self::assertEquals($this->createCompletionProofValue(), $asset->getCompletionProof());
+        self::assertSame($futureUpdatedAt, $asset->getUpdatedAt());
     }
 
     #[Test]
     public function itThrowsAssetDomainExceptionWhenMarkingUploadedAssetAsUploadedAgain(): void
     {
         // Arrange
-        $asset = $this->createPendingAsset();
-        $asset->markUploaded($this->createCompletionProofValue());
-        $this->expectException(AssetDomainException::class);
-        $this->expectExceptionMessage('Asset already uploaded');
+        $asset = $this->reconstituteUploadedAsset();
+        $originalUpdatedAt = $asset->getUpdatedAt();
 
         // Act
-        $asset->markUploaded($this->createCompletionProofValue('second-proof'));
+        $this->assertTransitionRejected(
+            fn () => $asset->markUploaded(new UploadCompletionProofValue('second-proof')),
+            'Asset already uploaded',
+            $asset,
+            $originalUpdatedAt,
+        );
     }
 
     #[Test]
     public function itThrowsAssetDomainExceptionWhenMarkingFailedAssetAsUploaded(): void
     {
         // Arrange
-        $asset = $this->createPendingAsset();
-        $asset->markFailed();
-        $this->expectException(AssetDomainException::class);
-        $this->expectExceptionMessage('Cannot upload asset from current state');
+        $asset = $this->reconstituteAsset(status: AssetStatus::FAILED);
+        $originalUpdatedAt = $asset->getUpdatedAt();
 
         // Act
-        $asset->markUploaded($this->createCompletionProofValue());
+        $this->assertTransitionRejected(
+            fn () => $asset->markUploaded(new UploadCompletionProofValue(self::COMPLETION_PROOF_VALUE)),
+            'Cannot upload asset from current state',
+            $asset,
+            $originalUpdatedAt,
+        );
     }
 
     #[Test]
     public function itReturnsAssetWithFailedStatusWhenMarkedFailed(): void
     {
         // Arrange
-        $asset = $this->createPendingAsset();
+        $asset = $this->reconstituteAsset();
+        $originalUpdatedAt = $asset->getUpdatedAt();
 
         // Act
         $asset->markFailed();
 
         // Assert
         self::assertSame(AssetStatus::FAILED, $asset->getStatus());
+        self::assertGreaterThan($originalUpdatedAt->getTimestamp(), $asset->getUpdatedAt()->getTimestamp());
+    }
+
+    #[Test]
+    public function itDoesNotMoveUpdatedAtBackwardWhenMarkingFailedWithFuturePersistedUpdatedAt(): void
+    {
+        // Arrange
+        $futureUpdatedAt = new DateTimeImmutable('2099-01-21T12:34:56+00:00');
+        $asset = $this->reconstituteAsset(updatedAt: $futureUpdatedAt);
+
+        // Act
+        $asset->markFailed();
+
+        // Assert
+        self::assertSame(AssetStatus::FAILED, $asset->getStatus());
+        self::assertSame($futureUpdatedAt, $asset->getUpdatedAt());
+    }
+
+    #[Test]
+    public function itDoesNotChangeUpdatedAtWhenMarkingFailedAssetAsFailedAgain(): void
+    {
+        // Arrange
+        $asset = $this->reconstituteAsset(status: AssetStatus::FAILED);
+        $originalUpdatedAt = $asset->getUpdatedAt();
+
+        // Act
+        $asset->markFailed();
+
+        // Assert
+        self::assertSame(AssetStatus::FAILED, $asset->getStatus());
+        self::assertSame($originalUpdatedAt, $asset->getUpdatedAt());
     }
 
     #[Test]
     public function itThrowsAssetDomainExceptionWhenMarkingUploadedAssetAsFailed(): void
     {
         // Arrange
-        $asset = $this->createPendingAsset();
-        $asset->markUploaded($this->createCompletionProofValue());
-        $this->expectException(AssetDomainException::class);
-        $this->expectExceptionMessage('Cannot mark an uploaded asset as failed');
+        $asset = $this->reconstituteUploadedAsset();
+        $originalUpdatedAt = $asset->getUpdatedAt();
 
         // Act
-        $asset->markFailed();
+        $this->assertTransitionRejected(
+            fn () => $asset->markFailed(),
+            'Cannot mark an uploaded asset as failed',
+            $asset,
+            $originalUpdatedAt,
+        );
     }
 
     #[Test]
@@ -262,7 +500,7 @@ final class AssetTest extends TestCase
             self::FILE_NAME,
             self::MIME_TYPE,
             AssetStatus::PENDING,
-            new DateTimeImmutable('2026-01-20T12:34:56+00:00'),
+            $this->persistedState(new DateTimeImmutable('2026-01-20T12:34:56+00:00')),
         );
         $secondAsset = Asset::reconstitute(
             new AssetId(self::ASSET_ID),
@@ -271,7 +509,7 @@ final class AssetTest extends TestCase
             'other-file.pdf',
             'application/pdf',
             AssetStatus::FAILED,
-            new DateTimeImmutable('2026-01-21T12:34:56+00:00'),
+            $this->persistedState(new DateTimeImmutable('2026-01-21T12:34:56+00:00')),
         );
 
         // Act
@@ -292,7 +530,7 @@ final class AssetTest extends TestCase
             self::FILE_NAME,
             self::MIME_TYPE,
             AssetStatus::PENDING,
-            new DateTimeImmutable('2026-01-20T12:34:56+00:00'),
+            $this->persistedState(new DateTimeImmutable('2026-01-20T12:34:56+00:00')),
         );
         $secondAsset = Asset::reconstitute(
             new AssetId(self::OTHER_ASSET_ID),
@@ -301,7 +539,7 @@ final class AssetTest extends TestCase
             self::FILE_NAME,
             self::MIME_TYPE,
             AssetStatus::PENDING,
-            new DateTimeImmutable('2026-01-20T12:34:56+00:00'),
+            $this->persistedState(new DateTimeImmutable('2026-01-20T12:34:56+00:00')),
         );
 
         // Act
@@ -324,18 +562,90 @@ final class AssetTest extends TestCase
         ];
     }
 
-    private function createPendingAsset(string $uploadId = self::FIRST_UPLOAD_ID): Asset
+    /**
+     * @return array<string, array{0: int}>
+     */
+    public static function invalidChunkCountProvider(): array
     {
-        return Asset::createPending(
-            new UploadId($uploadId),
+        return [
+            'zero chunks' => [0],
+            'negative chunks' => [-1],
+        ];
+    }
+
+    private function reconstituteAsset(
+        AssetStatus $status = AssetStatus::PENDING,
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null,
+        int $chunkCount = self::CHUNK_COUNT,
+    ): Asset {
+        $createdAt ??= new DateTimeImmutable(self::CREATED_AT);
+        $updatedAt ??= new DateTimeImmutable(self::UPDATED_AT);
+
+        return Asset::reconstitute(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
             new AccountId(self::ACCOUNT_ID),
             self::FILE_NAME,
             self::MIME_TYPE,
+            $status,
+            $this->persistedState($createdAt, $chunkCount, $updatedAt),
         );
+    }
+
+    private function reconstituteUploadedAsset(
+        ?DateTimeImmutable $createdAt = null,
+        ?DateTimeImmutable $updatedAt = null,
+        int $chunkCount = self::CHUNK_COUNT,
+        string $completionProof = self::COMPLETION_PROOF_VALUE,
+    ): Asset {
+        $createdAt ??= new DateTimeImmutable(self::CREATED_AT);
+        $updatedAt ??= new DateTimeImmutable(self::UPDATED_AT);
+
+        return Asset::reconstituteUploaded(
+            new AssetId(self::ASSET_ID),
+            new UploadId(self::FIRST_UPLOAD_ID),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            new UploadCompletionProofValue($completionProof),
+            $this->persistedState($createdAt, $chunkCount, $updatedAt),
+        );
+    }
+
+    /**
+     * @return array{createdAt: DateTimeImmutable, chunkCount: int, updatedAt: DateTimeImmutable}
+     */
+    private function persistedState(
+        DateTimeImmutable $createdAt,
+        int $chunkCount = self::DEFAULT_CHUNK_COUNT,
+        ?DateTimeImmutable $updatedAt = null,
+    ): array {
+        return [
+            'createdAt' => $createdAt,
+            'chunkCount' => $chunkCount,
+            'updatedAt' => $updatedAt ?? $createdAt,
+        ];
     }
 
     private function createCompletionProofValue(string $value = self::COMPLETION_PROOF_VALUE): UploadCompletionProofValue
     {
         return new UploadCompletionProofValue($value);
+    }
+
+    private function assertTransitionRejected(
+        callable $transition,
+        string $expectedMessage,
+        Asset $asset,
+        DateTimeImmutable $expectedUpdatedAt,
+    ): void {
+        try {
+            $transition();
+            self::fail('Expected AssetDomainException was not thrown');
+        } catch (AssetDomainException $exception) {
+            self::assertSame($expectedMessage, $exception->getMessage());
+        }
+
+        self::assertSame($expectedUpdatedAt, $asset->getUpdatedAt());
     }
 }

--- a/tests/Unit/Domain/Asset/AssetTest.php
+++ b/tests/Unit/Domain/Asset/AssetTest.php
@@ -634,7 +634,7 @@ final class AssetTest extends TestCase
     }
 
     private function assertTransitionRejected(
-        callable $transition,
+        \Closure $transition,
         string $expectedMessage,
         Asset $asset,
         DateTimeImmutable $expectedUpdatedAt,

--- a/tests/Unit/Domain/Asset/ValueObject/UploadTargetTest.php
+++ b/tests/Unit/Domain/Asset/ValueObject/UploadTargetTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 
 final class UploadTargetTest extends TestCase
 {
+    private const TRANSPORT_SECURITY_MESSAGE = 'Upload target URL must use HTTPS, except http://localhost, http://127.0.0.1, http://[::1], or mock://uploads for local development';
+
     #[Test]
     public function itReturnsUploadTargetWhenInputsAreValid(): void
     {
@@ -84,14 +86,14 @@ final class UploadTargetTest extends TestCase
     #[DataProvider('disallowedInsecureUrlProvider')]
     public function itThrowsInvalidArgumentExceptionWhenRemoteUrlDoesNotUseHttps(string $url): void
     {
-        // Arrange
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Upload target URL must use HTTPS, except http://localhost, http://127.0.0.1, or http://[::1] for local development'
-        );
+        $this->assertTransportSecurityFailure($url);
+    }
 
-        // Act
-        $this->createUploadTarget($url, []);
+    #[Test]
+    #[DataProvider('invalidMockUrlProvider')]
+    public function itThrowsInvalidArgumentExceptionWhenMockUrlDoesNotMatchTheAgreedLocalShape(string $url): void
+    {
+        $this->assertTransportSecurityFailure($url);
     }
 
     #[Test]
@@ -174,6 +176,29 @@ final class UploadTargetTest extends TestCase
         return [
             'remote http url' => ['http://example.test/upload'],
             'insecure localhost-like hostname' => ['http://localhost.example.test/upload'],
+            'unsupported ftp url' => ['ftp://example.test/upload'],
+            'unexpected mock host' => ['mock://downloads/123e4567-e89b-42d3-a456-426614174000/chunk/0'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidMockUrlProvider(): array
+    {
+        return [
+            'userinfo' => ['mock://user@uploads/123e4567-e89b-42d3-a456-426614174000/chunk/0'],
+            'explicit port' => ['mock://uploads:9000/123e4567-e89b-42d3-a456-426614174000/chunk/0'],
+            'query string' => ['mock://uploads/123e4567-e89b-42d3-a456-426614174000/chunk/0?partNumber=1'],
+            'fragment' => ['mock://uploads/123e4567-e89b-42d3-a456-426614174000/chunk/0#etag'],
+            'missing upload id segment' => ['mock://uploads/chunk/0'],
+            'empty upload id segment' => ['mock://uploads//chunk/0'],
+            'invalid upload id segment' => ['mock://uploads/not-an-upload-id/chunk/0'],
+            'wrong path literal' => ['mock://uploads/123e4567-e89b-42d3-a456-426614174000/chunks/0'],
+            'wrong chunk index' => ['mock://uploads/123e4567-e89b-42d3-a456-426614174000/chunk/1'],
+            'trailing slash' => ['mock://uploads/123e4567-e89b-42d3-a456-426614174000/chunk/0/'],
+            'traversal-like upload id' => ['mock://uploads/../chunk/0'],
+            'traversal-like middle segment' => ['mock://uploads/123e4567-e89b-42d3-a456-426614174000/../0'],
         ];
     }
 
@@ -200,7 +225,8 @@ final class UploadTargetTest extends TestCase
         return [
             'uppercase http scheme and host' => ['HTTP://LOCALHOST/path', 'http://localhost/path'],
             'mixed-case https with port, query, and fragment' => ['HTTPS://Example.COM:8443/Some/Path?Q=1#Frag', 'https://example.com:8443/Some/Path?Q=1#Frag'],
-            'userinfo with bracketed ipv6' => ['HTTPS://User:Pass@[2001:DB8::1]:8443/Some/Path?Q=1#Frag', 'https://User:Pass@[2001:db8::1]:8443/Some/Path?Q=1#Frag'],
+            'userinfo with bracketed ipv6' => ['HTTPS://User@[2001:DB8::1]:8443/Some/Path?Q=1#Frag', 'https://User@[2001:db8::1]:8443/Some/Path?Q=1#Frag'],
+            'mixed-case mock upload target' => ['MOCK://UPLOADS/123e4567-e89b-42d3-a456-426614174000/chunk/0', 'mock://uploads/123e4567-e89b-42d3-a456-426614174000/chunk/0'],
             'already normalized' => ['https://example.com/Already', 'https://example.com/Already'],
         ];
     }
@@ -217,5 +243,15 @@ final class UploadTargetTest extends TestCase
             new UploadCompletionProof('etag', UploadCompletionProofSource::RESPONSE_HEADER),
             new DateTimeImmutable('2026-01-20T12:34:56+00:00'),
         );
+    }
+
+    private function assertTransportSecurityFailure(string $url): void
+    {
+        // Arrange
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(self::TRANSPORT_SECURITY_MESSAGE);
+
+        // Act
+        $this->createUploadTarget($url, []);
     }
 }

--- a/tests/Unit/Infrastructure/Storage/MockStorageAdapterTest.php
+++ b/tests/Unit/Infrastructure/Storage/MockStorageAdapterTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Storage;
+
+use App\Domain\Asset\Asset;
+use App\Domain\Asset\AssetStatus;
+use App\Domain\Asset\UploadCompletionProofSource;
+use App\Domain\Asset\UploadHttpMethod;
+use App\Domain\Asset\ValueObject\AccountId;
+use App\Domain\Asset\ValueObject\AssetId;
+use App\Domain\Asset\ValueObject\UploadId;
+use App\Domain\Asset\ValueObject\UploadTarget;
+use App\Infrastructure\Storage\MockStorageAdapter;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MockStorageAdapterTest extends TestCase
+{
+    private const ACCOUNT_ID = 'account-123';
+    private const CREATED_AT = '2026-04-01T12:00:00+00:00';
+    private const DETERMINISTIC_EXPIRY = '2100-01-01T00:00:00+00:00';
+    private const FILE_NAME = 'image.png';
+    private const FIRST_ASSET_ID = '11111111-1111-4111-8111-111111111111';
+    private const FIRST_UPLOAD_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    private const MIME_TYPE = 'image/png';
+    private const SECOND_ASSET_ID = '22222222-2222-4222-8222-222222222222';
+    private const SECOND_UPLOAD_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    private const UPDATED_AT = '2026-04-01T12:05:00+00:00';
+
+    #[Test]
+    public function itReturnsADomainValidDeterministicTargetForAnAcceptedAsset(): void
+    {
+        // Arrange
+        $adapter = new MockStorageAdapter();
+        $asset = $this->pendingAsset(self::FIRST_ASSET_ID, self::FIRST_UPLOAD_ID, 4);
+
+        // Act
+        $target = $adapter->createUploadTarget($asset);
+
+        // Assert
+        self::assertSame('mock://uploads/' . self::FIRST_UPLOAD_ID . '/chunk/0', $target->url);
+        self::assertSame(UploadHttpMethod::PUT, $target->method);
+        self::assertSame([], $target->signedHeaders);
+        self::assertSame('etag', $target->completionProof->name);
+        self::assertSame(UploadCompletionProofSource::RESPONSE_HEADER, $target->completionProof->source);
+        self::assertEquals(new DateTimeImmutable(self::DETERMINISTIC_EXPIRY), $target->expiresAt);
+    }
+
+    #[Test]
+    public function itReturnsTheSameUploadTargetWhenCalledRepeatedlyForTheSameAsset(): void
+    {
+        // Arrange
+        $adapter = new MockStorageAdapter();
+        $asset = $this->pendingAsset(self::FIRST_ASSET_ID, self::FIRST_UPLOAD_ID);
+
+        // Act
+        $firstTarget = $adapter->createUploadTarget($asset);
+        $secondTarget = $adapter->createUploadTarget($asset);
+
+        // Assert
+        self::assertSame($this->targetSnapshot($firstTarget), $this->targetSnapshot($secondTarget));
+    }
+
+    #[Test]
+    public function itReturnsDifferentUrlsForDifferentAssets(): void
+    {
+        // Arrange
+        $adapter = new MockStorageAdapter();
+        $firstAsset = $this->pendingAsset(self::FIRST_ASSET_ID, self::FIRST_UPLOAD_ID);
+        $secondAsset = $this->pendingAsset(self::SECOND_ASSET_ID, self::SECOND_UPLOAD_ID);
+
+        // Act
+        $firstTarget = $adapter->createUploadTarget($firstAsset);
+        $secondTarget = $adapter->createUploadTarget($secondAsset);
+
+        // Assert
+        self::assertSame('mock://uploads/' . self::FIRST_UPLOAD_ID . '/chunk/0', $firstTarget->url);
+        self::assertSame('mock://uploads/' . self::SECOND_UPLOAD_ID . '/chunk/0', $secondTarget->url);
+    }
+
+    private function pendingAsset(string $assetId, string $uploadId, int $chunkCount = 1): Asset
+    {
+        return Asset::reconstitute(
+            new AssetId($assetId),
+            new UploadId($uploadId),
+            new AccountId(self::ACCOUNT_ID),
+            self::FILE_NAME,
+            self::MIME_TYPE,
+            AssetStatus::PENDING,
+            [
+                'createdAt' => new DateTimeImmutable(self::CREATED_AT),
+                'chunkCount' => $chunkCount,
+                'updatedAt' => new DateTimeImmutable(self::UPDATED_AT),
+            ],
+        );
+    }
+
+    /**
+     * @return array{
+     *     url: string,
+     *     method: string,
+     *     signedHeaders: list<string>,
+     *     completionProofName: string,
+     *     completionProofSource: string,
+     *     expiresAt: string
+     * }
+     */
+    private function targetSnapshot(UploadTarget $target): array
+    {
+        return [
+            'url' => $target->url,
+            'method' => $target->method->value,
+            'signedHeaders' => array_map(
+                static fn ($signedHeader): string => $signedHeader->name . ':' . $signedHeader->value,
+                $target->signedHeaders,
+            ),
+            'completionProofName' => $target->completionProof->name,
+            'completionProofSource' => $target->completionProof->source->value,
+            'expiresAt' => $target->expiresAt->format(DATE_ATOM),
+        ];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR implements durable local data persistence for the DAM system, extending the Asset domain model with lifecycle tracking and introducing a complete MySQL repository implementation with local-development mock storage support.

## Domain Model Enhancements

The `Asset` domain model now tracks additional lifecycle state:
- Added `chunkCount` (minimum 1) and `updatedAt` fields to complement existing `createdAt`
- Introduced `ClockInterface` abstraction for time-based operations, with `SystemClock` providing system time
- Updated factory methods (`createPending`, `reconstitute`, `reconstituteUploaded`) to accept lifecycle state as structured data rather than individual parameters
- State transitions (`markUploaded`, `markFailed`) now advance `updatedAt` with monotonic timestamp validation ensuring `updatedAt >= createdAt`
- Added public getters for `chunkCount` and `updatedAt`

## Repository & Persistence

**AssetRepositoryInterface** extended with:
- `searchByFileName(AccountId $accountId, string $query): array` - performs account-scoped, case-insensitive substring matching with results ordered by `createdAt` descending, then `id` ascending; returns empty list for blank queries after trimming

**MySQLAssetRepository** implementation provides:
- Insert-or-update save semantics with optimistic locking via `StaleAssetWriteException` on concurrent modifications
- Query operations: `findById`, `findByUploadId`, and `searchByFileName` with prepared statements
- Immutable field protection and state-transition validation
- Deterministic datetime handling with microsecond precision
- Prepared statement LIKE pattern escaping with custom escape character

**Database Schema** (`migrations/20260401120000_create_assets_table.sql`):
- `assets` table with columns for identity (`id`, `upload_id`), tenancy (`account_id`), file metadata, processing state, chunking, and optional completion proof
- Integrity constraints: status enum, `chunk_count >= 1`, lifecycle invariants, and `upload_id` uniqueness
- Timestamp columns with microsecond resolution and monotonic ordering guarantee

## Storage Adapter

`MockStorageAdapter` provides deterministic local-development upload targets:
- Returns mock URLs of the form `mock://uploads/{uploadId}/chunk/0`
- Supplies completion proof metadata (etag from response header) with fixed expiry
- Enables local testing without cloud storage dependencies

## UploadTarget & URL Validation

`UploadTarget.normalizeUrl()` enhanced to:
- Accept deterministic mock URLs (`mock://uploads/{uploadId}/chunk/0`) for local development
- Enforce strict mock URL shape validation (no userinfo, port, query, or fragment)
- Maintain existing HTTPS and localhost/loopback allowances for non-mock schemes
- Validate `uploadId` segments against UUID pattern

## Testing

Comprehensive test coverage added:
- **AssetsTableBootstrapTest**: Verifies schema creation, column types/nullability, indexes, and constraint enforcement
- **MySQLAssetRepositoryTest**: Integration tests covering CRUD operations, concurrent write protection, state transitions, search semantics, and error cases
- **MockStorageAdapterTest**: Unit tests verifying deterministic URL generation and completion proof metadata
- **AssetTest**: Extended with lifecycle field validation, invalid chunk count detection, and timestamp ordering assertions
- **UploadTargetTest**: Expanded mock URL shape validation covering path structure, segment validation, and malformed URL rejection

Helper utilities:
- `CompareAndSwapRacePdo` and `CompareAndSwapRaceStatement` for simulating concurrent write races in integration tests

## Documentation

- **ADR 04**: Updated Asset persistence contract documenting lifecycle field requirements and `searchByFileName` semantics
- **API Schema**: Clarified `UploadTarget.url` to specify HTTPS for production and deterministic mock form for local development
- **Implementation Log (US-03)**: Comprehensive documentation of delivered durable local data work, affected files, test outcomes, and follow-up wiring tasks
- **mkdocs.yml**: Added navigation entry for the implementation log

<!-- end of auto-generated comment: release notes by coderabbit.ai -->