### PR TITLE
feat: mark completed uploads as processing

### DIFF
--- a/docs/api/01-agree-api-schema.md
+++ b/docs/api/01-agree-api-schema.md
@@ -107,7 +107,7 @@ mutation StartUpload($input: StartUploadInput!) {
 
 ### `completeUpload(input: CompleteUploadInput!): CompleteUploadPayload!`
 
-Completes one upload after the client has sent the file and captured the required completion proof.
+Completes one upload after the client has sent the file and captured the required completion proof. When accepted, the asset moves into background processing immediately.
 
 **Input Fields**
 
@@ -121,8 +121,18 @@ Completes one upload after the client has sent the file and captured the require
 
 | Field           | Type            | Description                                                    |
 | --------------- | --------------- | -------------------------------------------------------------- |
-| `success.asset` | `Asset`         | Updated asset after a successful completion.                   |
+| `success.asset` | `Asset`         | Updated asset after a successful completion starts processing. |
 | `userErrors`    | `[UserError!]!` | Business validation errors when completion cannot be accepted. |
+
+**Business Error Codes**
+
+| Code                       | Meaning                                                                |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `ASSET_NOT_FOUND`          | The asset id does not exist in the authenticated caller account scope. |
+| `INVALID_ASSET_ID`         | The supplied asset id is not a valid asset identifier.                 |
+| `INVALID_UPLOAD_GRANT`     | The server-issued upload grant is missing or does not match the asset. |
+| `INVALID_COMPLETION_PROOF` | The completion proof is missing or blank.                              |
+| `INVALID_ASSET_STATE`      | The asset is already processing or is otherwise not completable now.   |
 
 **Example**
 
@@ -165,11 +175,12 @@ Non-negative file size in bytes. This allows values beyond the GraphQL `Int` ran
 
 ### `AssetStatus`
 
-| Value      | Meaning                                 |
-| ---------- | --------------------------------------- |
-| `PENDING`  | Upload has started but is not complete. |
-| `UPLOADED` | Upload completed successfully.          |
-| `FAILED`   | Upload failed.                          |
+| Value        | Meaning                                                 |
+| ------------ | ------------------------------------------------------- |
+| `PENDING`    | Upload has started but is not complete.                 |
+| `PROCESSING` | Upload completed and background processing has started. |
+| `UPLOADED`   | Upload completed successfully.                          |
+| `FAILED`     | Upload failed.                                          |
 
 ### `UploadTarget`
 
@@ -226,9 +237,9 @@ Clients must perform a network upload only when `UploadTarget.url` uses `https:/
 
 ### `CompleteUploadSuccess`
 
-| Field   | Type     | Description                                  |
-| ------- | -------- | -------------------------------------------- |
-| `asset` | `Asset!` | Updated asset after a successful completion. |
+| Field   | Type     | Description                                                    |
+| ------- | -------- | -------------------------------------------------------------- |
+| `asset` | `Asset!` | Updated asset after a successful completion starts processing. |
 
 ### `CompleteUploadPayload`
 

--- a/docs/logs/06-mark-upload-complete.md
+++ b/docs/logs/06-mark-upload-complete.md
@@ -1,0 +1,54 @@
+# Implementation Log: US-06 Mark Upload as Complete
+
+**Feature:** US-06 Mark Upload as Complete
+
+## Summary
+
+US-06 completed the upload-finalization path. A valid `completeUpload` call now accepts the client completion proof, moves the asset from `PENDING` to `PROCESSING`, persists that state, and dispatches a background processing job. Missing assets and invalid lifecycle states stay in the mutation payload as user-facing business errors rather than surfacing as GraphQL transport failures.
+
+## Implementation Details
+
+- Extended the asset lifecycle with `PROCESSING` so upload completion can represent the accepted post-upload state without pretending that downstream work has already finished.
+- Added `Asset::markProcessing(...)` plus processing-state reconstitution to keep the completion-proof invariant in the domain layer and preserve the proof after upload acceptance.
+- Added `AssetProcessingJobDispatcherInterface` at the application boundary and invoked it from `CompleteUploadService` only after a successful state transition and repository save.
+- Kept the GraphQL resolver thin by continuing to map only application results into the mutation payload while updating the SDL and handler expectations to expose the new `PROCESSING` status.
+- Tightened persistence coverage so the assets table accepts `PROCESSING` rows, still requires completion proof for proof-bearing states, and maps processing rows back into domain objects.
+- Extracted integration-test lifecycle row fixtures into a dedicated trait so the shared base test class stayed within the repository method-count rule.
+
+## Files Changed
+
+- `src/Application/Asset/AssetProcessingJobDispatcherInterface.php` — added the application port for scheduling background processing work.
+- `src/Application/Asset/CompleteUploadService.php` — changed upload completion to move assets into processing, persist them, and dispatch processing jobs.
+- `src/Domain/Asset/Asset.php` — added processing-state transition and reconstitution rules while preserving completion-proof invariants.
+- `src/Domain/Asset/AssetAccessors.php` — extracted accessor-heavy read methods from the aggregate to stay within the class-size limit.
+- `src/Domain/Asset/AssetStatus.php` — added the `PROCESSING` lifecycle enum value.
+- `src/GraphQL/Schema/schema.graphql` — documented `PROCESSING` in the GraphQL status enum and clarified the complete-upload mutation description.
+- `src/Infrastructure/Persistence/MySQLAssetRepository.php` — mapped persisted processing rows and reused proof validation for proof-bearing states.
+- `src/Infrastructure/Processing/MockAssetProcessingJobDispatcher.php` — provided the local/dev processing dispatcher stub.
+- `migrations/20260401120000_create_assets_table.sql` — allowed `PROCESSING` in the assets status constraint and required completion proof for processing rows.
+- `public/index.php` — wired the complete-upload service with the mock processing dispatcher.
+- `tests/Unit/Application/Asset/CompleteUploadServiceTest.php` — added service coverage for processing transition, job dispatch, and invalid-state rejections.
+- `tests/Unit/Http/GraphQLHandlerTest.php` — verified the local GraphQL handler returns `PROCESSING` and dispatches exactly one job on success.
+- `tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php` — added processing-row acceptance and processing-proof constraint coverage.
+- `tests/Integration/Infrastructure/Persistence/AssetLifecycleFixtureRows.php` — extracted shared lifecycle row fixtures from the oversized base test class.
+- `tests/Integration/Infrastructure/Persistence/BaseAssetsTableTestCase.php` — consumed the extracted fixture trait.
+- `tests/Integration/Infrastructure/Persistence/BaseMySQLAssetRepositoryTestCase.php` — added a processing-asset helper for repository tests.
+- `tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php` — updated repository lifecycle tests to persist the new processing transition.
+- `docs/api/01-agree-api-schema.md` — aligned the public API contract page with the shipped `completeUpload` behavior.
+
+## Validation
+
+- `vendor/bin/phpunit --configuration phpunit.xml tests/Unit/Domain/Asset/AssetTest.php tests/Unit/Application/Asset/CompleteUploadServiceTest.php tests/Unit/Http/GraphQLHandlerTest.php` — passed; PHPUnit reported only the existing missing code coverage driver warning.
+- `vendor/bin/phpunit --configuration phpunit.xml tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php` — passed inside the containerized PHP runtime with MySQL available.
+- `composer fix:check` — passed in the running app container after applying formatter-only normalization to the touched files.
+- `composer analyse` — passed.
+- `composer test` — passed.
+- `composer test:integration` — passed.
+- `composer check` — passed.
+- Editor diagnostics for the touched PHP files were clean after extracting the integration fixture trait and fixing trailing-newline issues.
+
+## Delivery Chunks
+
+- Lifecycle contract revision — introduced `PROCESSING` and updated the domain, schema, and persistence layers to treat it as the accepted post-upload state.
+- Background work dispatch — added the application port and local dispatcher stub so successful completions schedule processing work.
+- Focused verification and docs — tightened unit and integration coverage for accepted and rejected completion paths, then aligned the published API docs and implementation log.

--- a/migrations/20260401120000_create_assets_table.sql
+++ b/migrations/20260401120000_create_assets_table.sql
@@ -12,10 +12,10 @@ CREATE TABLE IF NOT EXISTS assets (
     PRIMARY KEY (id),
     KEY idx_assets_account_id (account_id),
     UNIQUE KEY uq_assets_upload_id (upload_id),
-    CONSTRAINT chk_assets_status CHECK (status IN ('PENDING', 'UPLOADED', 'FAILED')),
+    CONSTRAINT chk_assets_status CHECK (status IN ('PENDING', 'PROCESSING', 'UPLOADED', 'FAILED')),
     CONSTRAINT chk_assets_chunk_count_positive CHECK (chunk_count >= 1),
     CONSTRAINT chk_assets_completion_proof_matches_status CHECK (
-        (status = 'UPLOADED' AND completion_proof IS NOT NULL AND completion_proof REGEXP '[^[:space:]]')
+        (status IN ('PROCESSING', 'UPLOADED') AND completion_proof IS NOT NULL AND completion_proof REGEXP '[^[:space:]]')
         OR (status IN ('PENDING', 'FAILED') AND completion_proof IS NULL)
     ),
     CONSTRAINT chk_assets_updated_at_not_before_created_at CHECK (updated_at >= created_at)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,5 +23,6 @@ nav:
       - US-03 Data & Local Storage Setup: logs/03-data-local-storage-setup.md
       - US-04 Start Multi-file Upload: logs/04-start-multi-file-upload.md
       - US-05 Upload Request Validation: logs/05-upload-request-validation.md
+      - US-06 Mark Upload as Complete: logs/06-mark-upload-complete.md
 plugins:
   - search

--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ use App\GraphQL\SchemaFactory;
 use App\Http\Exception\MissingEnvironmentVariableException;
 use App\Http\GraphQLHandler;
 use App\Infrastructure\Persistence\MySQLAssetRepository;
+use App\Infrastructure\Processing\MockAssetProcessingJobDispatcher;
 use App\Infrastructure\Storage\MockStorageAdapter;
 use App\Infrastructure\Upload\LocalUploadGrantIssuer;
 use Monolog\Handler\StreamHandler;
@@ -117,7 +118,11 @@ try {
         new MockStorageAdapter(),
         $uploadGrantIssuer,
     );
-    $completeUploadService = new CompleteUploadService($assetRepository, $uploadGrantIssuer);
+    $completeUploadService = new CompleteUploadService(
+        $assetRepository,
+        $uploadGrantIssuer,
+        new MockAssetProcessingJobDispatcher(),
+    );
     $schemaFactory = new SchemaFactory(
         new StartUploadResolver($startUploadService),
         new StartUploadBatchResolver($startUploadService),

--- a/src/Application/Asset/AssetProcessingJobDispatcherInterface.php
+++ b/src/Application/Asset/AssetProcessingJobDispatcherInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Asset;
+
+use App\Domain\Asset\ValueObject\AssetId;
+
+interface AssetProcessingJobDispatcherInterface
+{
+    public function dispatch(AssetId $assetId): void;
+}

--- a/src/Application/Asset/CompleteUploadService.php
+++ b/src/Application/Asset/CompleteUploadService.php
@@ -34,6 +34,7 @@ final class CompleteUploadService
     public function __construct(
         private readonly AssetRepositoryInterface $assets,
         private readonly UploadGrantIssuerInterface $uploadGrantIssuer,
+        private readonly AssetProcessingJobDispatcherInterface $assetProcessingJobDispatcher,
     ) {
     }
 
@@ -70,8 +71,9 @@ final class CompleteUploadService
             $userErrors[] = new UserError(self::INVALID_UPLOAD_GRANT_CODE, self::INVALID_UPLOAD_GRANT_MESSAGE, 'uploadGrant');
         } else {
             try {
-                $asset->markUploaded($completionProof);
+                $asset->markProcessing($completionProof);
                 $this->assets->save($asset);
+                $this->assetProcessingJobDispatcher->dispatch($asset->getId());
                 $success = new CompleteUploadSuccess($this->mapAsset($asset));
             } catch (AssetDomainException $exception) {
                 $userErrors[] = $this->mapDomainException($exception);
@@ -105,6 +107,8 @@ final class CompleteUploadService
     {
         return match ($exception->getMessage()) {
             'Asset already uploaded' => new UserError(self::ASSET_ALREADY_UPLOADED_CODE, $exception->getMessage(), 'assetId'),
+            'Asset already processing' => new UserError(self::INVALID_ASSET_STATE_CODE, $exception->getMessage(), 'assetId'),
+            'Cannot process asset from current state' => new UserError(self::INVALID_ASSET_STATE_CODE, $exception->getMessage(), 'assetId'),
             'Cannot upload asset from current state' => new UserError(self::INVALID_ASSET_STATE_CODE, $exception->getMessage(), 'assetId'),
             default => new UserError(self::COMPLETE_UPLOAD_FAILED_CODE, $exception->getMessage()),
         };

--- a/src/Domain/Asset/Asset.php
+++ b/src/Domain/Asset/Asset.php
@@ -16,22 +16,12 @@ use DateTimeImmutable;
 
 final class Asset
 {
+    use AssetAccessors;
+
     private const DEFAULT_CHUNK_COUNT = 1;
     private const INVALID_CHUNK_COUNT_MESSAGE = 'Chunk count must be between 1 and 100.';
     private const INVALID_UPDATED_AT_MESSAGE = 'Updated at must not be earlier than created at';
     private const MAX_CHUNK_COUNT = 100;
-
-    private AssetId $id;
-    private UploadId $uploadId;
-    private AccountId $accountId;
-    private string $fileName;
-    private string $mimeType;
-    private AssetStatus $status;
-    private ?UploadCompletionProofValue $completionProof = null;
-    private int $chunkCount;
-    private DateTimeImmutable $createdAt;
-    private ClockInterface $clock;
-    private DateTimeImmutable $updatedAt;
 
     private function __construct(
         AssetId $id,
@@ -82,8 +72,8 @@ final class Asset
     }
 
     /**
-     * Reconstitutes a non-uploaded Asset from persistence.
-     * For UPLOADED status, use reconstituteUploaded() instead.
+     * Reconstitutes an Asset that does not require a completion proof from persistence.
+     * For PROCESSING or UPLOADED status, use reconstituteProcessing() or reconstituteUploaded() instead.
      *
      * @param array{createdAt: DateTimeImmutable, chunkCount?: int, updatedAt?: DateTimeImmutable} $persistedState
      *
@@ -105,6 +95,40 @@ final class Asset
             fileName: $fileName,
             mimeType: $mimeType,
             status: $status,
+        );
+        $asset->clock = new SystemClock();
+
+        $asset->initializeLifecycleState(
+            $persistedState['createdAt'],
+            $persistedState['chunkCount'] ?? self::DEFAULT_CHUNK_COUNT,
+            $persistedState['updatedAt'] ?? null,
+        );
+
+        return $asset;
+    }
+
+    /**
+     * @param array{createdAt: DateTimeImmutable, chunkCount?: int, updatedAt?: DateTimeImmutable} $persistedState
+     *
+     * @throws AssetDomainException
+     */
+    public static function reconstituteProcessing(
+        AssetId $id,
+        UploadId $uploadId,
+        AccountId $accountId,
+        string $fileName,
+        string $mimeType,
+        UploadCompletionProofValue $completionProof,
+        array $persistedState,
+    ): self {
+        $asset = new self(
+            id: $id,
+            uploadId: $uploadId,
+            accountId: $accountId,
+            fileName: $fileName,
+            mimeType: $mimeType,
+            status: AssetStatus::PROCESSING,
+            completionProof: $completionProof,
         );
         $asset->clock = new SystemClock();
 
@@ -179,13 +203,22 @@ final class Asset
      */
     private static function assertCompletionProofMatchesStatus(AssetStatus $status, ?UploadCompletionProofValue $completionProof): void
     {
-        if ($status === AssetStatus::UPLOADED && $completionProof === null) {
-            throw new AssetDomainException('Uploaded assets must have completion proof');
+        if (self::statusRequiresCompletionProof($status) && $completionProof === null) {
+            throw new AssetDomainException(match ($status) {
+                AssetStatus::PROCESSING => 'Processing assets must have completion proof',
+                AssetStatus::UPLOADED => 'Uploaded assets must have completion proof',
+                default => 'Assets in this state must have completion proof',
+            });
         }
 
-        if ($status !== AssetStatus::UPLOADED && $completionProof !== null) {
-            throw new AssetDomainException('Only uploaded assets can have completion proof');
+        if (! self::statusRequiresCompletionProof($status) && $completionProof !== null) {
+            throw new AssetDomainException('Only uploaded or processing assets can have completion proof');
         }
+    }
+
+    private static function statusRequiresCompletionProof(AssetStatus $status): bool
+    {
+        return $status === AssetStatus::PROCESSING || $status === AssetStatus::UPLOADED;
     }
 
     /**
@@ -233,6 +266,28 @@ final class Asset
     /**
      * @throws AssetDomainException
      */
+    public function markProcessing(UploadCompletionProofValue $completionProof): void
+    {
+        if ($this->status === AssetStatus::PROCESSING) {
+            throw new AssetDomainException('Asset already processing');
+        }
+
+        if ($this->status !== AssetStatus::PENDING) {
+            throw new AssetDomainException('Cannot process asset from current state');
+        }
+
+        $this->completionProof = $completionProof;
+        $this->status = AssetStatus::PROCESSING;
+        $nextUpdatedAt = $this->clock->now();
+
+        if ($nextUpdatedAt > $this->updatedAt) {
+            $this->updatedAt = $nextUpdatedAt;
+        }
+    }
+
+    /**
+     * @throws AssetDomainException
+     */
     public function markFailed(): void
     {
         if ($this->status === AssetStatus::UPLOADED) {
@@ -251,58 +306,4 @@ final class Asset
         }
     }
 
-    public function getId(): AssetId
-    {
-        return $this->id;
-    }
-
-    public function getUploadId(): UploadId
-    {
-        return $this->uploadId;
-    }
-
-    public function getAccountId(): AccountId
-    {
-        return $this->accountId;
-    }
-
-    public function getFileName(): string
-    {
-        return $this->fileName;
-    }
-
-    public function getMimeType(): string
-    {
-        return $this->mimeType;
-    }
-
-    public function getStatus(): AssetStatus
-    {
-        return $this->status;
-    }
-
-    public function getCompletionProof(): ?UploadCompletionProofValue
-    {
-        return $this->completionProof;
-    }
-
-    public function getChunkCount(): int
-    {
-        return $this->chunkCount;
-    }
-
-    public function getCreatedAt(): DateTimeImmutable
-    {
-        return $this->createdAt;
-    }
-
-    public function getUpdatedAt(): DateTimeImmutable
-    {
-        return $this->updatedAt;
-    }
-
-    public function equals(Asset $other): bool
-    {
-        return $this->id->equals($other->id);
-    }
 }

--- a/src/Domain/Asset/AssetAccessors.php
+++ b/src/Domain/Asset/AssetAccessors.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Asset;
+
+use App\Domain\Asset\ValueObject\AccountId;
+use App\Domain\Asset\ValueObject\AssetId;
+use App\Domain\Asset\ValueObject\UploadCompletionProofValue;
+use App\Domain\Asset\ValueObject\UploadId;
+use DateTimeImmutable;
+
+trait AssetAccessors
+{
+    private AssetId $id;
+    private UploadId $uploadId;
+    private AccountId $accountId;
+    private string $fileName;
+    private string $mimeType;
+    private AssetStatus $status;
+    private ?UploadCompletionProofValue $completionProof = null;
+    private int $chunkCount;
+    private DateTimeImmutable $createdAt;
+    private ClockInterface $clock;
+    private DateTimeImmutable $updatedAt;
+
+    public function getId(): AssetId
+    {
+        return $this->id;
+    }
+
+    public function getUploadId(): UploadId
+    {
+        return $this->uploadId;
+    }
+
+    public function getAccountId(): AccountId
+    {
+        return $this->accountId;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function getStatus(): AssetStatus
+    {
+        return $this->status;
+    }
+
+    public function getCompletionProof(): ?UploadCompletionProofValue
+    {
+        return $this->completionProof;
+    }
+
+    public function getChunkCount(): int
+    {
+        return $this->chunkCount;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->id->equals($other->id);
+    }
+}

--- a/src/Domain/Asset/AssetStatus.php
+++ b/src/Domain/Asset/AssetStatus.php
@@ -7,6 +7,7 @@ namespace App\Domain\Asset;
 enum AssetStatus: string
 {
     case PENDING = 'PENDING';
+    case PROCESSING = 'PROCESSING';
     case UPLOADED = 'UPLOADED';
     case FAILED = 'FAILED';
 }

--- a/src/GraphQL/Schema/schema.graphql
+++ b/src/GraphQL/Schema/schema.graphql
@@ -25,6 +25,9 @@ enum AssetStatus {
   "The upload has started but is not complete."
   PENDING
 
+  "The upload completed and background processing has started."
+  PROCESSING
+
   "The upload has been completed successfully."
   UPLOADED
 
@@ -283,6 +286,6 @@ type Mutation {
   "Start multiple uploads and receive one upload target per chunk for each accepted file."
   startUploadBatch(input: StartUploadBatchInput!): StartUploadBatchPayload!
 
-  "Complete one upload after the file is sent."
+  "Complete one upload after the file is sent and move it into processing."
   completeUpload(input: CompleteUploadInput!): CompleteUploadPayload!
 }

--- a/src/Infrastructure/Persistence/MySQLAssetRepository.php
+++ b/src/Infrastructure/Persistence/MySQLAssetRepository.php
@@ -346,13 +346,22 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
         $assetStatus = AssetStatus::from($status);
 
         return match ($assetStatus) {
+            AssetStatus::PROCESSING => Asset::reconstituteProcessing(
+                new AssetId($id),
+                new UploadId($uploadId),
+                new AccountId($accountId),
+                $fileName,
+                $mimeType,
+                $this->requiredCompletionProofValue($completionProof),
+                $persistedState,
+            ),
             AssetStatus::UPLOADED => Asset::reconstituteUploaded(
                 new AssetId($id),
                 new UploadId($uploadId),
                 new AccountId($accountId),
                 $fileName,
                 $mimeType,
-                $this->uploadedCompletionProofValue($completionProof),
+                $this->requiredCompletionProofValue($completionProof),
                 $persistedState,
             ),
             AssetStatus::PENDING,
@@ -379,10 +388,10 @@ final class MySQLAssetRepository implements AssetRepositoryInterface
         return $dateTime;
     }
 
-    private function uploadedCompletionProofValue(mixed $completionProof): UploadCompletionProofValue
+    private function requiredCompletionProofValue(mixed $completionProof): UploadCompletionProofValue
     {
         if (! is_string($completionProof)) {
-            throw new UnexpectedValueException('Uploaded assets must include a completion proof.');
+            throw new UnexpectedValueException('Assets in this state must include a completion proof.');
         }
 
         return new UploadCompletionProofValue($completionProof);

--- a/src/Infrastructure/Processing/Exception/RedisJobQueuePublisherException.php
+++ b/src/Infrastructure/Processing/Exception/RedisJobQueuePublisherException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Processing\Exception;
+
+use RuntimeException;
+
+final class RedisJobQueuePublisherException extends RuntimeException
+{
+    public static function publishFailed(): self
+    {
+        return new self('Failed to publish asset processing job.');
+    }
+
+    public static function extensionNotAvailable(): self
+    {
+        return new self('Redis extension is not available.');
+    }
+
+    public static function connectionFailed(): self
+    {
+        return new self('Failed to connect to the Redis job queue.');
+    }
+
+    public static function authenticationFailed(): self
+    {
+        return new self('Failed to authenticate with the Redis job queue.');
+    }
+}

--- a/src/Infrastructure/Processing/MockAssetProcessingJobDispatcher.php
+++ b/src/Infrastructure/Processing/MockAssetProcessingJobDispatcher.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Processing;
+
+use App\Application\Asset\AssetProcessingJobDispatcherInterface;
+use App\Domain\Asset\ValueObject\AssetId;
+
+final class MockAssetProcessingJobDispatcher implements AssetProcessingJobDispatcherInterface
+{
+    /**
+     * @var list<string>
+     */
+    private array $dispatchedAssetIds = [];
+
+    public function dispatch(AssetId $assetId): void
+    {
+        $this->dispatchedAssetIds[] = (string) $assetId;
+    }
+
+    /** @return list<string> */
+    public function dispatchedAssetIds(): array
+    {
+        return $this->dispatchedAssetIds;
+    }
+}

--- a/src/Infrastructure/Processing/RedisJobQueuePublisher.php
+++ b/src/Infrastructure/Processing/RedisJobQueuePublisher.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Processing;
+
+use App\Application\Asset\AssetProcessingJobDispatcherInterface;
+use App\Domain\Asset\ValueObject\AssetId;
+use App\Infrastructure\Processing\Exception\RedisJobQueuePublisherException;
+
+final class RedisJobQueuePublisher implements AssetProcessingJobDispatcherInterface
+{
+    private const DEFAULT_QUEUE_NAME = 'asset-processing';
+    private const INITIAL_RETRY_COUNT = 0;
+
+    /**
+     * @param \Closure $publishJob
+     * @phpstan-param \Closure(string, string): int $publishJob
+     */
+    public function __construct(
+        private readonly \Closure $publishJob,
+        private readonly string $queueName = self::DEFAULT_QUEUE_NAME,
+    ) {
+    }
+
+    public static function fromConnectionConfiguration(
+        string $host,
+        int $port,
+        ?string $password = null,
+        string $queueName = self::DEFAULT_QUEUE_NAME,
+    ): self {
+        $redis = self::connect($host, $port, $password);
+
+        return new self(
+            static fn (string $targetQueue, string $payload): int => self::pushJob($redis, $targetQueue, $payload),
+            $queueName,
+        );
+    }
+
+    public function dispatch(AssetId $assetId): void
+    {
+        $payload = json_encode([
+            'assetId' => (string) $assetId,
+            'retryCount' => self::INITIAL_RETRY_COUNT,
+        ], JSON_THROW_ON_ERROR);
+
+        ($this->publishJob)($this->queueName, $payload);
+    }
+
+    private static function connect(string $host, int $port, ?string $password): object
+    {
+        $redisClass = 'Redis';
+
+        if (! class_exists($redisClass)) {
+            throw RedisJobQueuePublisherException::extensionNotAvailable();
+        }
+
+        $redis = new $redisClass();
+
+        if (self::invokeRedisMethod($redis, 'connect', $host, $port) !== true) {
+            throw RedisJobQueuePublisherException::connectionFailed();
+        }
+
+        if ($password !== null && $password !== '' && self::invokeRedisMethod($redis, 'auth', $password) !== true) {
+            throw RedisJobQueuePublisherException::authenticationFailed();
+        }
+
+        return $redis;
+    }
+
+    private static function pushJob(object $redis, string $queueName, string $payload): int
+    {
+        $result = self::invokeRedisMethod($redis, 'rPush', $queueName, $payload);
+
+        if (! is_int($result)) {
+            throw RedisJobQueuePublisherException::publishFailed();
+        }
+
+        return $result;
+    }
+
+    private static function invokeRedisMethod(object $redis, string $method, mixed ...$arguments): mixed
+    {
+        return $redis->{$method}(...$arguments);
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/AssetLifecycleFixtureRows.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetLifecycleFixtureRows.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Persistence;
+
+trait AssetLifecycleFixtureRows
+{
+    /** @return array<string, int|string|null> */
+    protected function validPendingRow(): array
+    {
+        return [
+            'id' => '11111111-1111-4111-8111-111111111111',
+            'upload_id' => '22222222-2222-4222-8222-222222222222',
+            'account_id' => str_repeat('account-', 20),
+            'file_name' => str_repeat('very-long-file-name-', 18) . '.png',
+            'mime_type' => 'application/' . str_repeat('vnd.example.long-subtype-', 12) . 'json',
+            'status' => 'PENDING',
+            'chunk_count' => 1,
+            'completion_proof' => null,
+            'created_at' => '2026-04-01 12:00:00.000000',
+            'updated_at' => '2026-04-01 12:00:00.000000',
+        ];
+    }
+
+    /** @return array<string, int|string|null> */
+    protected function validFailedRow(): array
+    {
+        return array_replace(
+            $this->validPendingRow(),
+            [
+                'id' => '55555555-5555-4555-8555-555555555555',
+                'upload_id' => '66666666-6666-4666-8666-666666666666',
+                'status' => 'FAILED',
+                'chunk_count' => 2,
+                'updated_at' => '2026-04-01 12:03:00.000000',
+            ],
+        );
+    }
+
+    /** @return array<string, int|string|null> */
+    protected function validProcessingRow(): array
+    {
+        return array_replace(
+            $this->validPendingRow(),
+            [
+                'id' => '77777777-7777-4777-8777-777777777777',
+                'upload_id' => '88888888-8888-4888-8888-888888888888',
+                'status' => 'PROCESSING',
+                'chunk_count' => 3,
+                'completion_proof' => str_repeat('etag-processing-', 40),
+                'updated_at' => '2026-04-01 12:04:00.000000',
+            ],
+        );
+    }
+
+    /** @return array<string, int|string|null> */
+    protected function validUploadedRow(): array
+    {
+        return array_replace(
+            $this->validPendingRow(),
+            [
+                'id' => '33333333-3333-4333-8333-333333333333',
+                'upload_id' => '44444444-4444-4444-8444-444444444444',
+                'status' => 'UPLOADED',
+                'chunk_count' => 3,
+                'completion_proof' => str_repeat('etag-', 80),
+                'updated_at' => '2026-04-01 12:05:00.000000',
+            ],
+        );
+    }
+}

--- a/tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php
+++ b/tests/Integration/Infrastructure/Persistence/AssetsTableLifecycleTest.php
@@ -18,6 +18,7 @@ final class AssetsTableLifecycleTest extends BaseAssetsTableTestCase
         $this->withTemporarySchema(function (PDO $connection) use ($rowType): void {
             $row = match ($rowType) {
                 'pending' => $this->validPendingRow(),
+                'processing' => $this->validProcessingRow(),
                 'failed' => $this->validFailedRow(),
                 'uploaded' => $this->validUploadedRow(),
                 default => throw new \UnexpectedValueException('Unknown lifecycle row type'),
@@ -50,6 +51,7 @@ final class AssetsTableLifecycleTest extends BaseAssetsTableTestCase
         $this->withTemporarySchema(function (PDO $connection) use ($overrides, $message, $baseRowName, $expectedSqlState, $expectedMessageFragment, $preInsertBaseRow): void {
             $baseRow = $baseRowName === null ? null : match ($baseRowName) {
                 'pending' => $this->validPendingRow(),
+                'processing' => $this->validProcessingRow(),
                 'failed' => $this->validFailedRow(),
                 'uploaded' => $this->validUploadedRow(),
                 default => null,
@@ -75,6 +77,7 @@ final class AssetsTableLifecycleTest extends BaseAssetsTableTestCase
     {
         return [
             ['pending'],
+            ['processing'],
             ['failed'],
             ['uploaded'],
         ];
@@ -87,7 +90,7 @@ final class AssetsTableLifecycleTest extends BaseAssetsTableTestCase
     {
         return [
             'invalid status' => [
-                ['status' => 'PROCESSING'],
+                ['status' => 'READY'],
                 'Invalid status values must be rejected.',
                 'pending',
                 null,
@@ -114,6 +117,22 @@ final class AssetsTableLifecycleTest extends BaseAssetsTableTestCase
                 ['completion_proof' => 'etag-failed-row'],
                 'Non-uploaded failed assets must not persist a completion proof.',
                 'failed',
+                null,
+                'chk_assets_completion_proof_matches_status',
+                false,
+            ],
+            'processing without completion proof' => [
+                ['completion_proof' => null],
+                'Processing assets must persist a completion proof.',
+                'processing',
+                null,
+                'chk_assets_completion_proof_matches_status',
+                false,
+            ],
+            'processing with whitespace completion proof' => [
+                ['completion_proof' => " \t\n "],
+                'Whitespace-only completion proof values must be rejected for processing assets.',
+                'processing',
                 null,
                 'chk_assets_completion_proof_matches_status',
                 false,

--- a/tests/Integration/Infrastructure/Persistence/BaseAssetsTableTestCase.php
+++ b/tests/Integration/Infrastructure/Persistence/BaseAssetsTableTestCase.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseAssetsTableTestCase extends TestCase
 {
+    use AssetLifecycleFixtureRows;
+
     protected const ACCOUNT_ID_INDEX_NAME = 'idx_assets_account_id';
     protected const TABLE_NAME = 'assets';
     protected const FILE_NAME_COLLATION = 'utf8mb4_0900_ai_ci';
@@ -476,54 +478,6 @@ abstract class BaseAssetsTableTestCase extends TestCase
             'created_at' => $createdAt,
             'updated_at' => $updatedAt,
         ];
-    }
-
-    /** @return array<string, int|string|null> */
-    protected function validPendingRow(): array
-    {
-        return [
-            'id' => '11111111-1111-4111-8111-111111111111',
-            'upload_id' => '22222222-2222-4222-8222-222222222222',
-            'account_id' => str_repeat('account-', 20),
-            'file_name' => str_repeat('very-long-file-name-', 18) . '.png',
-            'mime_type' => 'application/' . str_repeat('vnd.example.long-subtype-', 12) . 'json',
-            'status' => 'PENDING',
-            'chunk_count' => 1,
-            'completion_proof' => null,
-            'created_at' => '2026-04-01 12:00:00.000000',
-            'updated_at' => '2026-04-01 12:00:00.000000',
-        ];
-    }
-
-    /** @return array<string, int|string|null> */
-    protected function validFailedRow(): array
-    {
-        return array_replace(
-            $this->validPendingRow(),
-            [
-                'id' => '55555555-5555-4555-8555-555555555555',
-                'upload_id' => '66666666-6666-4666-8666-666666666666',
-                'status' => 'FAILED',
-                'chunk_count' => 2,
-                'updated_at' => '2026-04-01 12:03:00.000000',
-            ],
-        );
-    }
-
-    /** @return array<string, int|string|null> */
-    protected function validUploadedRow(): array
-    {
-        return array_replace(
-            $this->validPendingRow(),
-            [
-                'id' => '33333333-3333-4333-8333-333333333333',
-                'upload_id' => '44444444-4444-4444-8444-444444444444',
-                'status' => 'UPLOADED',
-                'chunk_count' => 3,
-                'completion_proof' => str_repeat('etag-', 80),
-                'updated_at' => '2026-04-01 12:05:00.000000',
-            ],
-        );
     }
 
     protected function quoteIdentifier(string $identifier): string

--- a/tests/Integration/Infrastructure/Persistence/BaseMySQLAssetRepositoryTestCase.php
+++ b/tests/Integration/Infrastructure/Persistence/BaseMySQLAssetRepositoryTestCase.php
@@ -179,6 +179,28 @@ abstract class BaseMySQLAssetRepositoryTestCase extends BaseAssetsTableTestCase
     }
 
     /**
+     * @param array{createdAt: DateTimeImmutable, chunkCount: int, updatedAt: DateTimeImmutable} $persistedState
+     */
+    protected function processingAsset(
+        string $assetId,
+        string $uploadId,
+        string $accountId,
+        string $fileName,
+        string $completionProof,
+        array $persistedState,
+    ): Asset {
+        return Asset::reconstituteProcessing(
+            new AssetId($assetId),
+            new UploadId($uploadId),
+            new AccountId($accountId),
+            $fileName,
+            self::MIME_TYPE,
+            new UploadCompletionProofValue($completionProof),
+            $persistedState,
+        );
+    }
+
+    /**
      * @return array{createdAt: DateTimeImmutable, chunkCount: int, updatedAt: DateTimeImmutable}
      */
     protected function persistedState(string $createdAt, int $chunkCount = 1, ?string $updatedAt = null): array

--- a/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Persistence/MySQLAssetRepositoryTest.php
@@ -97,7 +97,7 @@ final class MySQLAssetRepositoryTest extends BaseMySQLAssetRepositoryTestCase
             );
 
             $repository->save($asset);
-            $asset->markUploaded(new UploadCompletionProofValue('etag-after-upload'));
+            $asset->markProcessing(new UploadCompletionProofValue('etag-after-upload'));
             $repository->save($asset);
             $persistedAsset = $repository->findById($asset->getId());
 
@@ -122,7 +122,7 @@ final class MySQLAssetRepositoryTest extends BaseMySQLAssetRepositoryTestCase
             $originalUpdatedAt = $asset->getUpdatedAt()->format(self::DATETIME_FORMAT);
 
             $repository->save($asset);
-            $asset->markUploaded(new UploadCompletionProofValue('etag-equal-updated-at'));
+            $asset->markProcessing(new UploadCompletionProofValue('etag-equal-updated-at'));
             $repository->save($asset);
             $persistedAsset = $repository->findById($asset->getId());
 

--- a/tests/Unit/Application/Asset/CompleteUploadServiceTest.php
+++ b/tests/Unit/Application/Asset/CompleteUploadServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Application\Asset;
 
+use App\Application\Asset\AssetProcessingJobDispatcherInterface;
 use App\Application\Asset\Command\CompleteUploadCommand;
 use App\Application\Asset\CompleteUploadService;
 use App\Application\Asset\UploadGrantIssuerInterface;
@@ -11,7 +12,9 @@ use App\Domain\Asset\Asset;
 use App\Domain\Asset\AssetRepositoryInterface;
 use App\Domain\Asset\AssetStatus;
 use App\Domain\Asset\ValueObject\AccountId;
+use App\Domain\Asset\ValueObject\UploadCompletionProofValue;
 use App\Domain\Asset\ValueObject\UploadId;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 final class CompleteUploadServiceTest extends TestCase
 {
     private AssetRepositoryInterface&MockObject $assets;
+    private AssetProcessingJobDispatcherInterface&MockObject $assetProcessingJobDispatcher;
     private UploadGrantIssuerInterface&MockObject $uploadGrantIssuer;
     private CompleteUploadService $service;
 
@@ -27,12 +31,17 @@ final class CompleteUploadServiceTest extends TestCase
         parent::setUp();
 
         $this->assets = $this->createMock(AssetRepositoryInterface::class);
+        $this->assetProcessingJobDispatcher = $this->createMock(AssetProcessingJobDispatcherInterface::class);
         $this->uploadGrantIssuer = $this->createMock(UploadGrantIssuerInterface::class);
-        $this->service = new CompleteUploadService($this->assets, $this->uploadGrantIssuer);
+        $this->service = new CompleteUploadService(
+            $this->assets,
+            $this->uploadGrantIssuer,
+            $this->assetProcessingJobDispatcher,
+        );
     }
 
     #[Test]
-    public function itMarksPendingAssetAsUploadedWhenGrantAndCompletionProofAreValid(): void
+    public function itMarksPendingAssetAsProcessingAndDispatchesAProcessingJobWhenGrantAndCompletionProofAreValid(): void
     {
         // Arrange
         $asset = $this->createPendingAsset();
@@ -52,6 +61,10 @@ final class CompleteUploadServiceTest extends TestCase
             ->method('issueForAsset')
             ->with($asset)
             ->willReturn('grant-123');
+        $this->assetProcessingJobDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($asset->getId());
 
         // Act
         $result = $this->service->completeUpload(
@@ -66,9 +79,9 @@ final class CompleteUploadServiceTest extends TestCase
         // Assert
         self::assertNotNull($result->success);
         self::assertSame([], $result->userErrors);
-        self::assertSame(AssetStatus::UPLOADED, $result->success->asset['status']);
+        self::assertSame(AssetStatus::PROCESSING, $result->success->asset['status']);
         self::assertCount(1, $savedAssets);
-        self::assertSame(AssetStatus::UPLOADED, $savedAssets[0]->getStatus());
+        self::assertSame(AssetStatus::PROCESSING, $savedAssets[0]->getStatus());
         self::assertSame('etag-123', $savedAssets[0]->getCompletionProof()?->value);
     }
 
@@ -79,6 +92,9 @@ final class CompleteUploadServiceTest extends TestCase
         $this->assets
             ->expects($this->never())
             ->method('findById');
+        $this->assetProcessingJobDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
         $this->uploadGrantIssuer
             ->expects($this->never())
             ->method('issueForAsset');
@@ -113,6 +129,9 @@ final class CompleteUploadServiceTest extends TestCase
         $this->assets
             ->expects($this->never())
             ->method('save');
+        $this->assetProcessingJobDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
         $this->uploadGrantIssuer
             ->expects($this->never())
             ->method('issueForAsset');
@@ -133,6 +152,42 @@ final class CompleteUploadServiceTest extends TestCase
     }
 
     #[Test]
+    public function itReturnsAssetNotFoundWhenTheAssetDoesNotExist(): void
+    {
+        // Arrange
+        $this->assets
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn(null);
+        $this->assets
+            ->expects($this->never())
+            ->method('save');
+        $this->assetProcessingJobDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+        $this->uploadGrantIssuer
+            ->expects($this->never())
+            ->method('issueForAsset');
+
+        // Act
+        $result = $this->service->completeUpload(
+            new CompleteUploadCommand(
+                accountId: 'account-123',
+                assetId: '123e4567-e89b-42d3-a456-426614174000',
+                uploadGrant: 'grant-123',
+                completionProof: 'etag-123',
+            ),
+        );
+
+        // Assert
+        self::assertNull($result->success);
+        self::assertCount(1, $result->userErrors);
+        self::assertSame('ASSET_NOT_FOUND', $result->userErrors[0]->code);
+        self::assertSame('Asset not found.', $result->userErrors[0]->message);
+        self::assertSame('assetId', $result->userErrors[0]->field);
+    }
+
+    #[Test]
     public function itReturnsAUserErrorWhenTheUploadGrantDoesNotMatchTheAsset(): void
     {
         // Arrange
@@ -144,6 +199,9 @@ final class CompleteUploadServiceTest extends TestCase
         $this->assets
             ->expects($this->never())
             ->method('save');
+        $this->assetProcessingJobDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
         $this->uploadGrantIssuer
             ->expects($this->once())
             ->method('issueForAsset')
@@ -165,6 +223,63 @@ final class CompleteUploadServiceTest extends TestCase
         self::assertSame('INVALID_UPLOAD_GRANT', $result->userErrors[0]->code);
     }
 
+    #[Test]
+    #[DataProvider('invalidCompletionStateProvider')]
+    public function itReturnsAUserErrorWhenTheAssetCannotBeCompletedFromItsCurrentState(AssetStatus $status, string $expectedMessage): void
+    {
+        // Arrange
+        $asset = match ($status) {
+            AssetStatus::UPLOADED => $this->createUploadedAsset(),
+            AssetStatus::PROCESSING => $this->createProcessingAsset(),
+            AssetStatus::FAILED => $this->createFailedAsset(),
+            default => throw new \UnexpectedValueException('Unsupported asset status for this test.'),
+        };
+        $this->assets
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn($asset);
+        $this->assets
+            ->expects($this->never())
+            ->method('save');
+        $this->assetProcessingJobDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+        $this->uploadGrantIssuer
+            ->expects($this->once())
+            ->method('issueForAsset')
+            ->with($asset)
+            ->willReturn('grant-123');
+
+        // Act
+        $result = $this->service->completeUpload(
+            new CompleteUploadCommand(
+                accountId: 'account-123',
+                assetId: (string) $asset->getId(),
+                uploadGrant: 'grant-123',
+                completionProof: 'etag-123',
+            ),
+        );
+
+        // Assert
+        self::assertNull($result->success);
+        self::assertCount(1, $result->userErrors);
+        self::assertSame('INVALID_ASSET_STATE', $result->userErrors[0]->code);
+        self::assertSame($expectedMessage, $result->userErrors[0]->message);
+        self::assertSame('assetId', $result->userErrors[0]->field);
+    }
+
+    /**
+     * @return array<string, array{0: AssetStatus, 1: string}>
+     */
+    public static function invalidCompletionStateProvider(): array
+    {
+        return [
+            'already uploaded' => [AssetStatus::UPLOADED, 'Cannot process asset from current state'],
+            'already processing' => [AssetStatus::PROCESSING, 'Asset already processing'],
+            'failed asset' => [AssetStatus::FAILED, 'Cannot process asset from current state'],
+        ];
+    }
+
     private function createPendingAsset(string $accountId = 'account-123'): Asset
     {
         return Asset::createPending(
@@ -173,5 +288,29 @@ final class CompleteUploadServiceTest extends TestCase
             'report.pdf',
             'application/pdf',
         );
+    }
+
+    private function createProcessingAsset(string $accountId = 'account-123'): Asset
+    {
+        $asset = $this->createPendingAsset($accountId);
+        $asset->markProcessing(new UploadCompletionProofValue('etag-processing'));
+
+        return $asset;
+    }
+
+    private function createFailedAsset(string $accountId = 'account-123'): Asset
+    {
+        $asset = $this->createPendingAsset($accountId);
+        $asset->markFailed();
+
+        return $asset;
+    }
+
+    private function createUploadedAsset(string $accountId = 'account-123'): Asset
+    {
+        $asset = $this->createPendingAsset($accountId);
+        $asset->markUploaded(new UploadCompletionProofValue('etag-uploaded'));
+
+        return $asset;
     }
 }

--- a/tests/Unit/Http/GraphQLHandlerTest.php
+++ b/tests/Unit/Http/GraphQLHandlerTest.php
@@ -16,6 +16,7 @@ use App\GraphQL\Resolver\StartUploadBatchResolver;
 use App\GraphQL\Resolver\StartUploadResolver;
 use App\GraphQL\SchemaFactory;
 use App\Http\GraphQLHandler;
+use App\Infrastructure\Processing\MockAssetProcessingJobDispatcher;
 use App\Infrastructure\Storage\MockStorageAdapter;
 use App\Infrastructure\Upload\LocalUploadGrantIssuer;
 use PHPUnit\Framework\Attributes\Test;
@@ -349,7 +350,7 @@ GRAPHQL,
     public function itExecutesCompleteUploadThroughTheLocalGraphQlHandler(): void
     {
         // Arrange
-        [$handler, $repository] = $this->createHandler();
+        [$handler, $repository, $assetProcessingJobDispatcher] = $this->createHandler();
         $asset = Asset::createPending(
             UploadId::generate(),
             new AccountId('local-test-account'),
@@ -393,31 +394,37 @@ GRAPHQL,
         self::assertSame(200, $response['status']);
         self::assertArrayNotHasKey('errors', $payload);
         self::assertSame([], $payload['data']['completeUpload']['userErrors']);
-        self::assertSame('UPLOADED', $payload['data']['completeUpload']['success']['asset']['status']);
+        self::assertSame('PROCESSING', $payload['data']['completeUpload']['success']['asset']['status']);
         self::assertSame('etag-complete', $repository->savedAssets[0]->getCompletionProof()?->value);
+        self::assertSame([(string) $asset->getId()], $assetProcessingJobDispatcher->dispatchedAssetIds());
     }
 
     /**
-     * @return array{0: GraphQLHandler, 1: InMemoryAssetRepository}
+     * @return array{0: GraphQLHandler, 1: InMemoryAssetRepository, 2: MockAssetProcessingJobDispatcher}
      */
     private function createHandler(): array
     {
         $repository = new InMemoryAssetRepository();
         $uploadGrantIssuer = new LocalUploadGrantIssuer('test-secret');
+        $assetProcessingJobDispatcher = new MockAssetProcessingJobDispatcher();
 
         $startUploadService = new StartUploadService(
             $repository,
             new MockStorageAdapter(),
             $uploadGrantIssuer,
         );
-        $completeUploadService = new CompleteUploadService($repository, $uploadGrantIssuer);
+        $completeUploadService = new CompleteUploadService(
+            $repository,
+            $uploadGrantIssuer,
+            $assetProcessingJobDispatcher,
+        );
         $schemaFactory = new SchemaFactory(
             new StartUploadResolver($startUploadService),
             new StartUploadBatchResolver($startUploadService),
             new CompleteUploadResolver($completeUploadService),
         );
 
-        return [new GraphQLHandler($schemaFactory, 'local-test-account', new NullLogger()), $repository];
+        return [new GraphQLHandler($schemaFactory, 'local-test-account', new NullLogger()), $repository, $assetProcessingJobDispatcher];
     }
 }
 

--- a/tests/Unit/Infrastructure/Processing/RedisJobQueuePublisherTest.php
+++ b/tests/Unit/Infrastructure/Processing/RedisJobQueuePublisherTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Processing;
+
+use App\Domain\Asset\ValueObject\AssetId;
+use App\Infrastructure\Processing\Exception\RedisJobQueuePublisherException;
+use App\Infrastructure\Processing\RedisJobQueuePublisher;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RedisJobQueuePublisherTest extends TestCase
+{
+    private const ASSET_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+    #[Test]
+    public function itPublishesAnAssetProcessingJobWithTheInitialRetryCount(): void
+    {
+        // Arrange
+        $capturedQueueName = null;
+        $capturedPayload = null;
+        $publisher = new RedisJobQueuePublisher(
+            static function (string $queueName, string $payload) use (&$capturedQueueName, &$capturedPayload): int {
+                $capturedQueueName = $queueName;
+                $capturedPayload = $payload;
+
+                return 1;
+            },
+        );
+
+        // Act
+        $publisher->dispatch(new AssetId(self::ASSET_ID));
+
+        // Assert
+        self::assertSame('asset-processing', $capturedQueueName);
+        self::assertSame([
+            'assetId' => self::ASSET_ID,
+            'retryCount' => 0,
+        ], json_decode((string) $capturedPayload, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function itThrowsWhenTheQueueWriteFails(): void
+    {
+        // Arrange
+        $publisher = new RedisJobQueuePublisher(
+            static function (string $_queueName, string $_payload): int {
+                self::assertIsString($_queueName);
+                self::assertIsString($_payload);
+
+                throw RedisJobQueuePublisherException::publishFailed();
+            },
+        );
+
+        // Act & Assert
+        $this->expectException(RedisJobQueuePublisherException::class);
+        $this->expectExceptionMessage('Failed to publish asset processing job.');
+        $publisher->dispatch(new AssetId(self::ASSET_ID));
+    }
+}


### PR DESCRIPTION
## Summary

This pull request implements US-06 by introducing a new `PROCESSING` asset lifecycle state that marks the transition between upload completion and final readiness. Previously, completed uploads transitioned directly to `UPLOADED`; now they transition to `PROCESSING` and dispatch background processing jobs, enabling the system to track and report on the post-upload processing phase.

## Key Changes

### Domain Model (`src/Domain/Asset/`)
- Added `AssetStatus::PROCESSING` enum case representing the background processing phase
- Introduced `Asset::markProcessing(UploadCompletionProofValue)` method to transition assets from `PENDING` to `PROCESSING` with completion proof storage
- Added `Asset::reconstituteProcessing()` static factory for persistence reconstitution with proof validation
- Extracted getter methods and equality logic into reusable `AssetAccessors` trait to reduce direct property access
- Updated completion proof validation to require proofs for both `PROCESSING` and `UPLOADED` states

### Application Service (`src/Application/Asset/`)
- Integrated `AssetProcessingJobDispatcherInterface` as a constructor dependency in `CompleteUploadService`
- Modified completion workflow to call `$asset->markProcessing($completionProof)` instead of upload-finalization logic
- Dispatches background jobs via `$assetProcessingJobDispatcher->dispatch($asset->getId())` after successful state transition
- Extended error mapping to treat asset state exceptions (`'Asset already processing'`, `'Cannot process asset from current state'`) as `INVALID_ASSET_STATE` user errors

### Infrastructure (`src/Infrastructure/`)
- Updated `MySQLAssetRepository` to reconstitute `PROCESSING` assets from the database with completion proof validation
- Defined `AssetProcessingJobDispatcherInterface` contract for extensible job dispatch implementations
- Added `MockAssetProcessingJobDispatcher` for testing with asset ID tracking capability

### Database (`migrations/20260401120000_create_assets_table.sql`)
- Extended `chk_assets_status` constraint to include `'PROCESSING'` as a valid state
- Refined `chk_assets_completion_proof_matches_status` to require non-null, non-whitespace completion proof when status is `PROCESSING` or `UPLOADED`
- Maintained proof nullability requirement for `PENDING` and `FAILED` states

### GraphQL Schema (`src/GraphQL/Schema/schema.graphql`)
- Added `PROCESSING` enum value to `AssetStatus` type
- Updated `completeUpload` mutation documentation to reflect processing-state transition semantics

### Testing
- Created `AssetLifecycleFixtureRows` trait providing consistent database fixture methods (`validPendingRow()`, `validProcessingRow()`, `validUploadedRow()`, `validFailedRow()`)
- Enhanced `CompleteUploadServiceTest` with dispatch verification and state transition assertions
- Added test coverage for invalid completion states (`UPLOADED`, `PROCESSING`, `FAILED`) and missing assets
- Integrated tests for completion proof validation constraints
- Updated `MySQLAssetRepositoryTest` to use `markProcessing()` instead of `markUploaded()`

### Documentation
- Created implementation log (`docs/logs/06-mark-upload-complete.md`) documenting the feature
- Updated API schema documentation with `PROCESSING` status and business error codes (`ASSET_NOT_FOUND`, `INVALID_ASSET_ID`, `INVALID_UPLOAD_GRANT`, `INVALID_COMPLETION_PROOF`, `INVALID_ASSET_STATE`)
- Added MkDocs navigation entry for the implementation log

## Quality Assurance
All validation checks passed:
- `composer fix:check` — Code style verification
- `composer analyse` — Static type and code quality analysis  
- `composer test` — Unit test suite
- `composer test:integration` — Integration test suite
- `composer check` — Overall validation

## Acceptance Criteria Fulfillment
1. ✓ **Successful completion starts processing** — Assets transition to `PROCESSING` with immediate background job dispatch and no errors
2. ✓ **File not found** — Non-existent assets return `ASSET_NOT_FOUND` user error with no job dispatch
3. ✓ **Invalid state transitions** — Assets in `PROCESSING`, `UPLOADED`, or `FAILED` states return `INVALID_ASSET_STATE` user error with no job dispatch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->